### PR TITLE
api: convert IMAGE.size.{width,height} to 2RD

### DIFF
--- a/include/dwg.h
+++ b/include/dwg.h
@@ -3727,11 +3727,7 @@ typedef struct _dwg_entity_IMAGE
   BITCODE_3BD pt0;
   BITCODE_3BD uvec;
   BITCODE_3BD vvec;
-  struct
-  {
-    BITCODE_RD width;
-    BITCODE_RD height;
-  } size;
+  BITCODE_2RD size; /*!< DXF 13/23; width, height in pixel */
   BITCODE_BS display_props;
   BITCODE_B clipping;
   BITCODE_RC brightness;
@@ -3924,11 +3920,7 @@ typedef struct _dwg_entity_WIPEOUT
   BITCODE_3BD pt0;
   BITCODE_3BD uvec;
   BITCODE_3BD vvec;
-  struct
-  {
-    BITCODE_RD width;
-    BITCODE_RD height;
-  } size;
+  BITCODE_2RD size;
   BITCODE_BS display_props;
   BITCODE_B clipping;
   BITCODE_RC brightness;

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3606,8 +3606,7 @@ DWG_ENTITY(IMAGE)
   FIELD_3DPOINT (pt0, 10);
   FIELD_3DPOINT (uvec, 11);
   FIELD_3DPOINT (vvec, 12);
-  FIELD_RD (size.width, 13);
-  FIELD_RD (size.height, 23);
+  FIELD_2RD (size, 13);
   FIELD_BS (display_props, 70);
   FIELD_B (clipping, 280);
   FIELD_RC (brightness, 281);
@@ -5481,8 +5480,7 @@ DWG_ENTITY(WIPEOUT)
   FIELD_3DPOINT (pt0, 10);
   FIELD_3DPOINT (uvec, 11);
   FIELD_3DPOINT (vvec, 12);
-  FIELD_RD (size.width, 13);
-  FIELD_RD (size.height, 23);
+  FIELD_2RD (size, 13);
   FIELD_BS (display_props, 70);
   FIELD_B (clipping, 280);
   FIELD_RC (brightness, 281);

--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -13350,12 +13350,12 @@ dwg_ent_image_set_v_vector(dwg_ent_image *restrict image,
  */
 double
 dwg_ent_image_get_size_height(const dwg_ent_image *restrict image,
-                          int *restrict error)
+                              int *restrict error)
 {
   if (image)
     {
       *error = 0;
-      return image->size.height;
+      return image->size.y;
     }
   else
     {
@@ -13369,13 +13369,13 @@ dwg_ent_image_get_size_height(const dwg_ent_image *restrict image,
  */
 void
 dwg_ent_image_set_size_height(dwg_ent_image *restrict image,
-                          const double size_height,
+                              const double size_height,
                               int *restrict error)
 {
   if (image)
     {
       *error = 0;
-      image->size.height = size_height;
+      image->size.y = size_height;
     }
   else
     {
@@ -13388,12 +13388,12 @@ dwg_ent_image_set_size_height(dwg_ent_image *restrict image,
  */
 double
 dwg_ent_image_get_size_width(const dwg_ent_image *restrict image,
-                          int *restrict error)
+                             int *restrict error)
 {
   if (image)
     {
       *error = 0;
-      return image->size.width;
+      return image->size.x;
     }
   else
     {
@@ -13407,13 +13407,13 @@ dwg_ent_image_get_size_width(const dwg_ent_image *restrict image,
  */
 void
 dwg_ent_image_set_size_width(dwg_ent_image *restrict image,
-                          const double size_width,
+                             const double size_width,
                              int *restrict error)
 {
   if (image)
     {
       *error = 0;
-      image->size.width = size_width;
+      image->size.x = size_width;
     }
   else
     {
@@ -13751,7 +13751,7 @@ dwg_ent_image_get_num_clip_verts(const dwg_ent_image *restrict image,
  */
 BITCODE_2RD *
 dwg_ent_image_get_clip_verts(const dwg_ent_image *restrict image,
-                          int *restrict error)
+                             int *restrict error)
 {
   BITCODE_2RD *ptx = calloc(image->num_clip_verts, sizeof(BITCODE_2RD));
   if (ptx)


### PR DESCRIPTION
no inline structs in WIPEOUT and IMAGE.
convert inline struct { width; height } to 2RD (x,y).
The size is documented as size (u,v),
not width/height in the AutoCAD DXF docs.

This is mostly to simplify the dynapi #59