### PR TITLE
Revert dat position in dwg_decode_add_object in all return cases.

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -3474,7 +3474,11 @@ dwg_decode_add_object(Dwg_Data *restrict dwg, Bit_Chain* dat, Bit_Chain* hdl_dat
    */
   realloced = dwg_add_object(dwg);
   if (realloced > 0)
-    return realloced; // i.e. DWG_ERR_OUTOFMEM
+    {
+      dat->byte = oldpos;
+      dat->bit = previous_bit;
+      return realloced; // i.e. DWG_ERR_OUTOFMEM
+    }
   obj = &dwg->object[num];
   LOG_INFO("==========================================\n"
            "Object number: %lu/%lX", (unsigned long)num, (unsigned long)num)


### PR DESCRIPTION
dat position must be reverted. See `decode_R13_R2000` Object-map, section 2. 
In `while (dat->byte - startpos < section_size)` loop.