### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@
 # STEP 1 build executable binary
 ############################
 
-FROM python:2.7.17-buster AS extracting
+FROM python:3.7.7-buster AS extracting
 LABEL maintainer="azoulayos@protonmail.com"
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends git autoconf libtool swig texinfo build-essential gcc python-libxml2 && \
-    LIBXML2VER=2.9.1 && \
+    apt-get install -y --no-install-recommends git autoconf libtool swig texinfo build-essential gcc python3-libxml2 && \
+    LIBXML2VER=2.9.9 && \
     mkdir libxmlInstall && cd libxmlInstall && \
     wget ftp://xmlsoft.org/libxml2/libxml2-$LIBXML2VER.tar.gz && \
     tar xf libxml2-$LIBXML2VER.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+############################
+# STEP 1 build executable binary
+############################
+
+FROM python:2.7.17-buster AS extracting
+LABEL maintainer="azoulayos@protonmail.com"
+RUN apt-get update && apt-get upgrade -y &&\
+    apt-get install -y git autoconf libtool swig texinfo build-essential gcc python-libxml2 && \
+    LIBXML2VER=2.9.1 && \
+    mkdir libxmlInstall && cd libxmlInstall && \
+    wget ftp://xmlsoft.org/libxml2/libxml2-$LIBXML2VER.tar.gz && \
+    tar xf libxml2-$LIBXML2VER.tar.gz && \
+    cd libxml2-$LIBXML2VER/ && \
+    ./configure && \
+    make && \
+    make install && \
+    cd /libxmlInstall && \
+    rm -rf gg libxml2-$LIBXML2VER.tar.gz libxml2-$LIBXML2VER
+WORKDIR /app
+RUN git clone git://git.sv.gnu.org/libredwg.git && \
+     cd libredwg && \
+     sh autogen.sh && \
+     ./configure --enable-trace --prefix=/usr/local && \
+     make && \
+     mkdir ldwg && \
+     make install DESTDIR=$PWD/ldwg && \
+     make check DESTDIR=$PWD/ldwg
+     
+############################
+# STEP 2 copy the executable binary to thinest image
+############################
+
+FROM bitnami/minideb:jessie
+LABEL maintainer="azoulayos@protonmail.com"
+COPY --from=extracting /app/libredwg/ldwg/usr/local/bin/* /usr/local/bin/
+COPY --from=extracting /app/libredwg/ldwg/usr/local/include/* /usr/local/include/
+COPY --from=extracting /app/libredwg/ldwg/usr/local/lib/* /usr/local/lib/
+RUN ldconfig
+
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 
 FROM python:2.7.17-buster AS extracting
 LABEL maintainer="azoulayos@protonmail.com"
-RUN apt-get update && apt-get upgrade -y &&\
-    apt-get install -y git autoconf libtool swig texinfo build-essential gcc python-libxml2 && \
+RUN apt-get update &&\
+    apt-get install -y --no-install-recommends git autoconf libtool swig texinfo build-essential gcc python-libxml2 && \
     LIBXML2VER=2.9.1 && \
     mkdir libxmlInstall && cd libxmlInstall && \
     wget ftp://xmlsoft.org/libxml2/libxml2-$LIBXML2VER.tar.gz && \
@@ -36,5 +36,6 @@ COPY --from=extracting /app/libredwg/ldwg/usr/local/include/* /usr/local/include
 COPY --from=extracting /app/libredwg/ldwg/usr/local/lib/* /usr/local/lib/
 RUN ldconfig
 
+CMD [ "sh" ]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,7 @@ RUN git clone git://git.sv.gnu.org/libredwg.git && \
 # STEP 2 copy the executable binary to thinest image
 ############################
 
-FROM bitnami/minideb:jessie
-LABEL maintainer="azoulayos@protonmail.com"
+FROM debian:stable-slim
 COPY --from=extracting /app/libredwg/ldwg/usr/local/bin/* /usr/local/bin/
 COPY --from=extracting /app/libredwg/ldwg/usr/local/include/* /usr/local/include/
 COPY --from=extracting /app/libredwg/ldwg/usr/local/lib/* /usr/local/lib/


### PR DESCRIPTION
Hi,

**Pull Request purpose**

I created a Dockerfile that can generate a stable image for using libreDWG.
I've tested this image and it works with different kind of DWG files.

**What I've done ?**

I began from a python2.7 because test suites of libreDWG are written with this technology.
After comment of the maintainer : I changed it to python 3.7

For libxml, i had many issues by installing this library and the only way i managed it was by compiling the libxml directly from the source code.

Then i build a multistage to get a thin and deployable image : i used debian slim and not alpine because i did not manage to link the binaries with alipne (ldconfig).

**Go further**

In one of my project (https://github.com/yossefaz/dwg_transformer/tree/master/transformer) i use this image with an interface (a program in Golang) thant can receive request from a Queue to convert DWG files in different format.

I could also write a more generic program like mine, in order to expose all libreDWG commands to the Docker image. In this way users could interact directly out of the container to convert any kind of DWG : this would allow to run libreDWG in Docker.