### PR TITLE
Fix 1.4 version

### DIFF
--- a/include/dwg.h
+++ b/include/dwg.h
@@ -249,7 +249,7 @@ typedef enum DWG_VERSION_TYPE
   R_INVALID,
   R_1_1,	/* MC0.0  MicroCAD Release 1.1 */
   R_1_2,	/* AC1.2  AutoCAD Release 1.2 */
-  R_1_4,	/* AC1.4  AutoCAD Release 1.4 */
+  R_1_4,	/* AC1.40 AutoCAD Release 1.4 */
   R_2_0,	/* AC1.50 AutoCAD Release 2.0 */
   R_2_1,	/* AC2.10 AutoCAD Release 2.10 */
   R_2_5,	/* AC1002 AutoCAD Release 2.5 */

--- a/src/common.c
+++ b/src/common.c
@@ -65,7 +65,7 @@ const char version_codes[DWG_VERSIONS][7] = {
   "INVALI", // R_INVALID
   "MC0.0",  /* DWG Release 1.1 (as MicroCAD) */
   "AC1.2",  /* DWG Release 1.2 (as AutoCAD) */
-  "AC1.4",  /* DWG Release 1.4 */
+  "AC1.40", /* DWG Release 1.4 */
   "AC1.50", /* DWG Release 2.0 */
   "AC2.10", /* DWG Release 2.10 */
   "AC1002", // DWG Release 2.5                   9


### PR DESCRIPTION
DWG magic for this version is "AC1.40", not "AC1.4".