### PR TITLE
Update README, Fix typo in install instructions

### DIFF
--- a/README
+++ b/README
@@ -74,7 +74,7 @@ Optionally:
 See INSTALL for generic instructions.  Basically, you do:
 
 $ sh ./autogen.sh (if you checked out the source code from git)
-$ ./configure [--enable-trace] [--disable--write] [--disable-shared]
+$ ./configure [--enable-trace] [--disable-write] [--disable-shared]
 $ make
 $ make check
 $ sudo make install


### PR DESCRIPTION
Fixed a small typo in the README file which led to: "configure: WARNING: unrecognized options: --disable--write". Especially when copy & pasting the install instructions.

**Disclaimer**: This is my first contribution to a open source project and I don't know if I have done it correctly (e.g. correct branch and so on). :)