### PR TITLE
possible buffer overflow.

### DIFF
--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -25236,8 +25236,8 @@ dwg_add_XRECORD_handle (Dwg_Object_XRECORD *restrict _obj,
     _obj->xdata = rbuf;
   _obj->num_xdata++;
   rbuf->type = dxf;
-  memcpy (rbuf->value.hdl, &hdl, sizeof (Dwg_Handle));
-  _obj->xdata_size += 10; // 2 + 8
+  memcpy (rbuf->value.h, &hdl, sizeof (Dwg_Handle));
+  _obj->xdata_size += 2+sizeof (Dwg_Handle); // 2 + 8
   return _obj;
 }
 


### PR DESCRIPTION
at function `dwg_add_XRECORD_handle` on line 25239, an attempt is made to write 24 bytes into an 8-byte array.
maybe I'm wrong, but this is not what you wanted.
structure `Dwg_Handle` corresponds to 24 bytes on an x64 system.
and this write can lead to unexpected results, such as violation of data integrity and even accessibility of the program.

you may have asked to fill in field `value.h`