### PR TITLE
Fix various typos

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -68,8 +68,8 @@ someone should probably think about and resolve them!
 * make regen-dynapi
 
   Whenever you change a class or any class field (add, remove, rename, change a type),
-  add a seperate make regen-dynapi commit, as result of this command. So the small change
-  is seperated from the automatically created changes by gen-dynapi.pl.
+  add a separate make regen-dynapi commit, as result of this command. So the small change
+  is separated from the automatically created changes by gen-dynapi.pl.
 
   This command updates several generated lists of objects, classes, and its tests.
 

--- a/NEWS
+++ b/NEWS
@@ -160,7 +160,7 @@ API breaking changes:
     and setters. Re-enable with -DUSE_DEPRECATED_API
   * Renamed UNDERLAY to {PDF,DGN,DWF}UNDERLAY and likewise PDFDEFINITION, ...
 Minor features:
-  * fix more C++ compatiblity: restrict is __restrict, disable __nonnull.
+  * fix more C++ compatibility: restrict is __restrict, disable __nonnull.
     Now successfully used in SolveSpace.
   * Add gperf hash tables for all objects and dxfclasses, for faster lookup
     dxfnames to create classes, and object names with most properties.
@@ -308,7 +308,7 @@ New features:
     r2013, r2018, but not r2007), but this does not work fully yet.
   * Added all remaining Dwg_Version types: R_1_3 for AC1.3, R_2_4 for AC1001, and
     AC1013 for R_13c3.
-  * The header can now be compiled wth C++ compilers, needed for some bindings.
+  * The header can now be compiled with C++ compilers, needed for some bindings.
     Re-arranged nested structs, names, malloc casts, reserved keywords like this,
     template.
     Started with the gambas bindings, a Visual Basic clone for unix.
@@ -388,7 +388,7 @@ API breaking changes:
     DIMSTYLE got a new flag0. flag is computed from that.
     VPORT_ENTITY_HEADER flag1 => is_on, vport_entity => viewport, xref_handle => xref,
       new prev_entity handle.
-    MLINESTYLE index/ltype union changed to seperate lt_index, lt_ltype fields.
+    MLINESTYLE index/ltype union changed to separate lt_index, lt_ltype fields.
       They were overwriting each other on version conversions.
     MLINESTYLE.desc => description, data_length => data_size.
     HATCH booleans got a is_ prefix.
@@ -409,11 +409,11 @@ API breaking changes:
 Major bugfixes:
   * Fixed converting ASCII from and to Unicode strings, when converting across
     versions. Embed Unicode as \U+XXXX into ASCII, and decode it back to Unicode.
-    Honor dat,dwg->from_version and use the new FIELD_T as seperate type. (GH #185)
+    Honor dat,dwg->from_version and use the new FIELD_T as separate type. (GH #185)
   * Invalid numbers (read failures) are converted to 0.0 in the released version.
   * Fixed wrong CMC color reads and writes, check the method, lookup the index,
     support a CMTC truecolor-only type.
-  * Fixed EED writes, by writing to seperate streams and merging them at the end,
+  * Fixed EED writes, by writing to separate streams and merging them at the end,
     with proper size calculation.
   * All remaining assertions are now protected. (GH #187)
 
@@ -422,9 +422,9 @@ Minor bugfixes:
     with the new sections.
   * Normalize extrusion vectors.
   * Fix bit_write_BT, the thickness vector pre-R2000.
-  * Added many overflow checks, due to extensive fuzzing campains.
+  * Added many overflow checks, due to extensive fuzzing campaigns.
   * Fixed wrong julian date conversions with TIMEBLL types.
-  * Fxed keyword conflicts with the bindings: No next, from, self fieldnames.
+  * Fixed keyword conflicts with the bindings: No next, from, self fieldnames.
   * Many more, see the ChangeLog.
 
 Other newsworthy changes:
@@ -438,7 +438,7 @@ Other newsworthy changes:
   * CMC color got 2 new fields: raw (EMC only), method (the first rgb byte).
   * Many DXF re-ordering fixes.
 
-Notes: The new constraint and dynblock objects just miss a major refactor into seperate
+Notes: The new constraint and dynblock objects just miss a major refactor into separate
 impl subclasses, and subent and curve support.
 
 LibreDWG version 0.10.1 - released 2020/01/13 - beta:
@@ -828,7 +828,7 @@ New features:
   * Added --disable-dxf, --enable--debug configure options. With debug there are many
     more unstable objects available.
   * Added libredwg.pc (GH #30)
-  * Added valgrind supressions for known darwin/glibc leaks.
+  * Added valgrind suppressions for known darwin/glibc leaks.
   * Changed and clarified the semver version numbering on development checkouts with
     major.minor[.patch[.build.nonmastercommits-gittag]]. See HACKING.
 

--- a/build-aux/codecov_io.sh
+++ b/build-aux/codecov_io.sh
@@ -155,7 +155,7 @@ cat << EOF
 
     -c           Move discovered coverage reports to the trash
     -z FILE      Upload specified file directly to Codecov and bypass all report generation.
-                 This is inteded to be used only with a pre-formatted Codecov report and is not
+                 This is intended to be used only with a pre-formatted Codecov report and is not
                  expected to work under any other circumstances.
     -Z           Exit with 1 if not successful. Default will Exit with 0
 

--- a/doc/LibreDWG.texi
+++ b/doc/LibreDWG.texi
@@ -541,7 +541,7 @@ With r11 came the additional tables:
 @node OBJECTS_
 @section OBJECTS Section
 
-The OBJECTS Section is usually split up into multiple pages (seperate sections of type AcDbObjects)
+The OBJECTS Section is usually split up into multiple pages (separate sections of type AcDbObjects)
 and contains all entities and objects. It is indexed by @ref{HANDLES}.
 
 @xref{Objects, OBJECTS}.
@@ -560,7 +560,7 @@ Objects in @strong{stable} classes are treated as the fixed-type objects with fu
 Objects in @strong{unstable} classes are sometimes written to DXF or JSON, but not to DWG. Changes are not treated as API breaking. Usually such objects are converted to UNKNOWN_OBJ or UNKNOWN_ENT objects, and when written to DWG converted to PLACEHOLDER, DUMMY or POINT objects with EED pointing to the original class and content.
 Only when rewriting from-to the very same version with the full known unknown_bits blob (e.g. dwgrewrite or json) such classes can persist as such.
 
-Objects in @strong{debugging} classes are only handled with the develper @code{configure --enable-debug} flag, otherwise ignored. See unstable above.
+Objects in @strong{debugging} classes are only handled with the developer @code{configure --enable-debug} flag, otherwise ignored. See unstable above.
 
 Objects in @strong{undhandled} classes are always ignored. There are no fields known, only it's type.
 
@@ -715,7 +715,7 @@ Since r13 all those tables are stored as table control objects and
 tablerecord objects.
 
 From pre-r13 DWG's these tables are imported as old r11 sections and
-as new CONTROL objects, so that all entities are accessable via the
+as new CONTROL objects, so that all entities are accessible via the
 single BLOCK_CONTROL.model_space -> BLOCK_HEADER.entities iterator,
 all layers via the LAYER_CONTROL.entries -> LAYER objects, and so on.
 All blocks are accessed via all other model_space BLOCK_HEADER's,
@@ -918,7 +918,7 @@ Encoding DWG files, i.e. DWG write support, can be disabled via
 one is currently r13-r2000. Experimentally work is ongoing for the r2004
 format, which is also used for r2010, r2013, and r2018.
 The r2007 format version is not covered yet.
-The pre-r13 formats are much simplier and can be written, but need some
+The pre-r13 formats are much simpler and can be written, but need some
 hand-holding and manual conversions when converting from newer formats still.
 
 See @file{src/in_dxf.c} for a high-level usage example.
@@ -975,12 +975,12 @@ With the add api you can easily create an empty DWG from scratch, add table entr
 or variables Dictionaries), and add entities. To set more entity fields use the @ref{dynapi}.
 
 For each almost each entity and table exists a function at to add it, with arguments to initialize some fields
-as in the VBA object model. The other objects are either created automatically, or handled seperately.
+as in the VBA object model. The other objects are either created automatically, or handled separately.
 
 All BITCODE_T strings are encoded as UTF-8, as with the dynapi. @xref{strings}.
 Most names are copied, since most names are considered to be constant.
 If not, you need to free them by yourself.
-Exceptions are dxfname (there exists a seperate dxfname_u variant),
+Exceptions are dxfname (there exists a separate dxfname_u variant),
 the VX name, which does not exists anymore since r2000.
 
 A very simple example using the add API is the example program @xref{dwgadd}.
@@ -1080,7 +1080,7 @@ This accesses the Header (or sometimes also called Database) fields.
 This accesses a subclass, a structure within the object.
 @end deftypefn
 
-The setters don't differentiate betwen common values and strings.
+The setters don't differentiate between common values and strings.
 
 @deftypefn {Function} bool dwg_dynapi_entity_set_value (dwg_ent_generic *@var{_obj}, const char *@var{fieldname}, const void *@var{value}, const bool @var{is_utf8})
 Sets the ENTITY.fieldname to a value.

--- a/examples/dwgadd.5
+++ b/examples/dwgadd.5
@@ -146,7 +146,7 @@ The dwgadd program accepts this input format to add entities and objects
 to a \s-1DWG\s0 file.
 .SH "COMMANDS"
 .IX Header "COMMANDS"
-commands start at each new line and must begin with a keyword and has optional agruments.
+commands start at each new line and must begin with a keyword and has optional arguments.
 .PP
 comments start with # and are ignored.
 .PP

--- a/examples/dwgadd.pod
+++ b/examples/dwgadd.pod
@@ -11,7 +11,7 @@ to a DWG file.
 
 =head1 COMMANDS
 
-commands start at each new line and must begin with a keyword and has optional agruments.
+commands start at each new line and must begin with a keyword and has optional arguments.
 
 comments start with # and are ignored.
 

--- a/examples/dwgfuzz.c
+++ b/examples/dwgfuzz.c
@@ -11,7 +11,7 @@
 /*****************************************************************************/
 
 /*
- * dwgfuzz.c: afl++/honggfuzz fuzzing for all in- and exporters. Just not the seperate ones.
+ * dwgfuzz.c: afl++/honggfuzz fuzzing for all in- and exporters. Just not the separate ones.
  *
  * Also usable like:
     ../configure --disable-shared --disable-bindings CC=hfuzz-clang CFLAGS='-O2 -g -fsanitize=address,undefined -fno-omit-frame-pointer -I/usr/local/include' && make -C src && make -C examples dwgfuzz

--- a/examples/llvmfuzz.c
+++ b/examples/llvmfuzz.c
@@ -38,7 +38,7 @@
 extern int LLVMFuzzerTestOneInput(const unsigned char *data, size_t size);
 
 // libfuzzer limitation:
-// Enforce NULL-termination of the input buffer, to avoid bugus reports. copy it.
+// Enforce NULL-termination of the input buffer, to avoid bogus reports. copy it.
 // Problematic is mostly strtol(3) which also works with \n termination.
 static int enforce_null_termination(Bit_Chain *dat, bool enforce)
 {

--- a/include/dwg.h
+++ b/include/dwg.h
@@ -4873,7 +4873,7 @@ typedef struct _dwg_entity_HELIX
 } Dwg_Entity_HELIX;
 
 // TODO ACSH_SWEEP_CLASS has different names,
-// ACIS (sweep:options) even more so. ACIS key names are weird though, Acad didnt take them.
+// ACIS (sweep:options) even more so. ACIS key names are weird though, Acad didn't take them.
 #define SWEEPOPTIONS_fields  \
   BITCODE_BD draft_angle;   	   /*!< DXF 42 */ \
   BITCODE_BD draft_start_distance; /*!< DXF 43 */ \

--- a/include/dwg_api.h
+++ b/include/dwg_api.h
@@ -6221,7 +6221,7 @@ EXPORT dwg_class *dwg_get_class (const dwg_data *dwg, unsigned int index);
    Most names are copied, since most names are considered to be constant.
    If not, you need to free them by yourself.
 
-   Exceptions are dxfname (there exists a seperate dxfname_u variant),
+   Exceptions are dxfname (there exists a separate dxfname_u variant),
    the VX name, which does not exists anymore since r2000.
 
    When writing DWG, a version of R_2000 is recommended, only R_2 - R-2000

--- a/programs/dwgfilter.1
+++ b/programs/dwgfilter.1
@@ -5,7 +5,7 @@ dwgfilter \- manual page for dwgfilter 0.12.5
 .SH DESCRIPTION
 dwgfilter [OPTIONS...] dwgfile
 .PP
-Allow custom jq queries on a temporay JSON dump.
+Allow custom jq queries on a temporary JSON dump.
 .PP
 OPTIONS: \fB\-\-help\fR,\-\-version
 .TP

--- a/programs/dwgfilter.in
+++ b/programs/dwgfilter.in
@@ -7,7 +7,7 @@ version() {
 help() {
     echo "dwgfilter [OPTIONS...] dwgfile"
     echo ""
-    echo "Allow custom jq queries on a temporay JSON dump."
+    echo "Allow custom jq queries on a temporary JSON dump."
     echo ""
     echo "OPTIONS: --help,--version"
     echo "  --debug  keep the tmp json"

--- a/src/bits.c
+++ b/src/bits.c
@@ -1261,7 +1261,7 @@ bit_read_H (Bit_Chain *restrict dat, Dwg_Handle *restrict handle)
 
 /** Write handle-references.
  *  TODO
- *  seperate SoftPtr:   BB 0 + RLL
+ *  separate SoftPtr:   BB 0 + RLL
  *           HardPtr:   BB 1 + RLL
  *           SoftOwner: BB 2 + RLL
  *           HardOwner: BB 3 + RLL

--- a/src/classes.c
+++ b/src/classes.c
@@ -930,7 +930,7 @@ const char* dwg_type_dxfname (const Dwg_Object_Type type)
     return NULL;
   else
     {
-      //LOG_ERROR ("Unkown object type %d", type)
+      //LOG_ERROR ("Unknown object type %d", type)
       return NULL;
     }
 }

--- a/src/common.h
+++ b/src/common.h
@@ -55,7 +55,7 @@
 #pragma message("_GNUC_VERSION " STR(_GNUC_VERSION))
 */
 
-// clang-specifics (rarely needed, as they mimic GCC dignostics closely, even down to bugs)
+// clang-specifics (rarely needed, as they mimic GCC diagnostics closely, even down to bugs)
 #if defined(__clang__) || defined(__clang)
 #  define HAVE_CLANG
 #  define CLANG_DIAG_IGNORE(x)                                                \

--- a/src/dec_macros.h
+++ b/src/dec_macros.h
@@ -1147,7 +1147,7 @@
               _obj->o.name[vcount] = bit_read_RLL (dat);                      \
               break;                                                          \
             default:                                                          \
-              LOG_ERROR ("Unkown FIELD_VECTOR_TYPE " #name " typesize %d",    \
+              LOG_ERROR ("Unknown FIELD_VECTOR_TYPE " #name " typesize %d",    \
                          typesize);                                           \
               break;                                                          \
             }                                                                 \

--- a/src/decode.c
+++ b/src/decode.c
@@ -2973,7 +2973,7 @@ read_2004_section_preview (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
   return error;
 }
 
-/* For decrypt and encrypt: symetric, as it's just a simple XOR with a one-time pad,
+/* For decrypt and encrypt: symmetric, as it's just a simple XOR with a one-time pad,
    generated here on the fly. */
 void
 decrypt_R2004_header (BITCODE_RC *restrict dest, const BITCODE_RC *restrict src,
@@ -3248,7 +3248,7 @@ decode_R2007 (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
  * EED "Extended Entity Data":
  * There's an array of obj->num_eed obj->eed[] entries.
  * Each eed member has size, handle, the raw[size] buffer and the decoded data.
- * Each obj->eed[].data member is further seperated into DXF+1000 codes, for
+ * Each obj->eed[].data member is further separated into DXF+1000 codes, for
  * strings, numbers, points, ...
  * Those subgroups have an empty raw, size, and the prev. handle.
  */

--- a/src/decode_r2007.c
+++ b/src/decode_r2007.c
@@ -1299,7 +1299,7 @@ obj_stream_position (Bit_Chain *restrict dat, Bit_Chain *restrict hdl_dat,
   /* all 3 now relative to obj */
   unsigned long p2 = bit_position (hdl_dat);
   SINCE (R_2007)
-    { // but only since 2007 there is a seperate string stream
+    { // but only since 2007 there is a separate string stream
       unsigned long p3 = bit_position (str_dat);
       if (p2 > p1)
         return p3 > p2 ? p3 : p2;

--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -25703,7 +25703,7 @@ dwg_geom_transform_OCS (dwg_point_3d *out,
 // and the scale vector as last row.
 typedef double dwg_matrix9[9];
 
-// Via the arbitray axis algorithm we can define the 3 rotations (dwg_matrix9)
+// Via the arbitrary axis algorithm we can define the 3 rotations (dwg_matrix9)
 // as a single normal. This helper function creates the rotation matrix from the
 // normal vector.
 static void

--- a/src/encode.c
+++ b/src/encode.c
@@ -622,7 +622,7 @@ const unsigned char unknown_section[53]
               bit_write_RLL (dat, _obj->o.name[vcount]);                      \
               break;                                                          \
             default:                                                          \
-              LOG_ERROR ("Unkown SUB_FIELD_VECTOR_TYPE " #nam " typesize %d", \
+              LOG_ERROR ("Unknown SUB_FIELD_VECTOR_TYPE " #nam " typesize %d", \
                          typesize);                                           \
               break;                                                          \
             }                                                                 \
@@ -4138,7 +4138,7 @@ dwg_encode_add_object (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   while (dat->byte + obj->size >= dat->size)
     bit_chain_alloc (dat);
 
-  // First write an aproximate size here.
+  // First write an approximate size here.
   // Then calculate size from the fields. Either <0x7fff or more.
   // Patch it afterwards and check old<>new size if enough space allocated.
   bit_write_MS (dat, obj->size);

--- a/src/gen-dynapi.pl
+++ b/src/gen-dynapi.pl
@@ -981,7 +981,7 @@ for (sort @entity_names) {
   }
   my $aref = $SUBCLASSES{$_};
   unshift @$aref, 'AcDbEntity';
-  $SUBCLASSES{$_} = $aref; # if it didnt exist
+  $SUBCLASSES{$_} = $aref; # if it didn't exist
   my $len = @$aref;
   $max_subclasses = $len if $len > $max_subclasses;
 }
@@ -1007,7 +1007,7 @@ for (sort @object_names) {
   } else {
     unshift @$aref, 'AcDbObject';
   }
-  $SUBCLASSES{$_} = $aref; # if it didnt exist
+  $SUBCLASSES{$_} = $aref; # if it didn't exist
   my $len = @$aref;
   $max_subclasses = $len if $len > $max_subclasses;
 }
@@ -1939,7 +1939,7 @@ sub out_classes {
     }
 }
 
-# generate API's lists per stabilty
+# generate API's lists per stability
 my $tmpl;
 my $api_c = "$srcdir/dwg_api.c";
 open $in, "<", $api_c or die "$api_c: $!";

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -8311,7 +8311,7 @@ dxf_postprocess_PLOTSETTINGS (Dwg_Object *restrict obj)
     _obj->plotview_name = dwg_handle_name (dwg, "VIEW", _obj->plotview);
 }
 
-// seperate model_space and paper_space into its own fields, out of entries[]
+// separate model_space and paper_space into its own fields, out of entries[]
 static int
 move_out_BLOCK_CONTROL (Dwg_Object *restrict obj,
                         Dwg_Object_BLOCK_CONTROL *restrict _ctrl,
@@ -9318,7 +9318,7 @@ new_object (char *restrict name, char *restrict dxfname,
               *i_p = i + 1;
               if (strEQc (name, "BLOCK_RECORD"))
                 {
-                  // seperate mspace and pspace into its own fields
+                  // separate mspace and pspace into its own fields
                   Dwg_Object_BLOCK_CONTROL *_ctrl
                       = ctrl->tio.object->tio.BLOCK_CONTROL;
                   if (!strcasecmp (pair->value.s, "*Paper_Space"))
@@ -9350,7 +9350,7 @@ new_object (char *restrict name, char *restrict dxfname,
                 }
               else if (strEQc (name, "LTYPE"))
                 {
-                  // seperate bylayer and byblock into its own fields
+                  // separate bylayer and byblock into its own fields
                   Dwg_Object_LTYPE_CONTROL *_ctrl
                       = ctrl->tio.object->tio.LTYPE_CONTROL;
                   if (!strcasecmp (pair->value.s, "ByLayer"))

--- a/src/in_json.c
+++ b/src/in_json.c
@@ -2203,7 +2203,7 @@ _set_struct_field (Bit_Chain *restrict dat, const Dwg_Object *restrict obj,
                   tokens->index++;
                   for (int ki = 0; ki < keys; ki++)
                     {
-                      // seperate subclass type loop
+                      // separate subclass type loop
                       const Dwg_DYNAPI_field *f1;
                       char key1[80];
                       char *rest;
@@ -2382,7 +2382,7 @@ _set_struct_field (Bit_Chain *restrict dat, const Dwg_Object *restrict obj,
           else
             {
               // failed_key.rest.nextfieldatteept
-              *(rest - 1) = '.'; // unsuccesfull search, set the dot back
+              *(rest - 1) = '.'; // unsuccessful search, set the dot back
               rest = strchr (rest, '.');
               if (rest)
                 {

--- a/src/out_json.c
+++ b/src/out_json.c
@@ -671,7 +671,7 @@ field_cmc (Bit_Chain *dat, const char *restrict key,
                                    (BITCODE_RLL)_obj->o.nam[vcount]);         \
               break;                                                          \
             default:                                                          \
-              LOG_ERROR ("Unkown SUB_FIELD_VECTOR_TYPESIZE " #nam             \
+              LOG_ERROR ("Unknown SUB_FIELD_VECTOR_TYPESIZE " #nam             \
                          " typesize %d", typesize);                           \
               break;                                                          \
             }                                                                 \
@@ -1814,7 +1814,7 @@ json_header_write (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
 {
   int error = 0;
   RECORD (HEADER); // single hash
-  // seperate funcs to catch the return, and end with ENDRECORD
+  // separate funcs to catch the return, and end with ENDRECORD
   PRE (R_13)
     error = json_preR13_header_write_private (dat, dwg);
   LATER_VERSIONS

--- a/src/spec.h
+++ b/src/spec.h
@@ -285,7 +285,7 @@
             SUB_FIELD (o, nam[vcount], RLL, dxf);                             \
             break;                                                            \
           default:                                                            \
-            LOG_ERROR ("Unkown SUB_FIELD_VECTOR_TYPE " #nam " typesize %d",   \
+            LOG_ERROR ("Unknown SUB_FIELD_VECTOR_TYPE " #nam " typesize %d",   \
                        typesize);                                             \
             break;                                                            \
           }                                                                   \

--- a/test/unit-testing/tests_common.h
+++ b/test/unit-testing/tests_common.h
@@ -175,7 +175,7 @@ strtobt (const char *binarystring)
 
 #endif
 
-// make -s makes it silent, but can be overidden by VERBOSE=1
+// make -s makes it silent, but can be overridden by VERBOSE=1
 int is_make_silent(void)
 {
   const char *make = getenv("MAKEFLAGS");

--- a/test/xmlsuite/common.c
+++ b/test/xmlsuite/common.c
@@ -40,7 +40,7 @@ spointprepare (double x, double y, double z)
 }
 
 /*
- * This functions coverts double format in char to be emitted in the XML
+ * This functions converts double format in char to be emitted in the XML
  * @param double x The double digis to be converted in string
  *
  * @return char* Return the converted double in string. Return empty string if
@@ -65,7 +65,7 @@ doubletochar (double x)
 }
 
 /*
- * This functions coverts int format in char to be emitted in the XML
+ * This functions converts int format in char to be emitted in the XML
  *
  * @return char* Return the converted double in string. Return empty string if
  * error


### PR DESCRIPTION
Found via `codespell -q 3 -S ChangeLog -L 2rd,ba,childs,daa,ded,fo,oce,ro,siz`