### PR TITLE
Fixes Heap-buffer-overflow in decode_preR13_section_hdr

### DIFF
--- a/src/decode_r11.c
+++ b/src/decode_r11.c
@@ -696,6 +696,12 @@ decode_preR13 (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
   // setup all the new control objects
   error |= dwg_add_Document (dwg, 0);
 
+  if (dwg->header.numsections < 3)
+    {
+      LOG_ERROR ("Invalid number of sections %zu", dat->size)
+      return DWG_ERR_INVALIDDWG;
+    }
+
   // 5 tables + header + block. VIEW = 6
   dwg->header.section = (Dwg_Section *)calloc (sizeof (Dwg_Section),
                                                dwg->header.numsections + 2);


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46983

Heap buffer overflow happens because in `decode_preR13` when header sections are allocated the `dwg->header.numsections` is equal zero and the memory only for 2 sections is allocated.

```cpp
  // 5 tables + header + block. VIEW = 6
  dwg->header.section = (Dwg_Section *)calloc (sizeof (Dwg_Section),
                                               dwg->header.numsections + 2);
```

However it makes assumption that there are 5 sections later:
```cpp
    // The 5 tables (num_sections always 5): 3 RS + 1 RL address
    LOG_INFO ("==========================================\n")
    if (decode_preR13_section_hdr ("BLOCK", SECTION_BLOCK, dat, dwg)
        || decode_preR13_section_hdr ("LAYER", SECTION_LAYER, dat, dwg)
        || decode_preR13_section_hdr ("STYLE", SECTION_STYLE, dat, dwg)
        || decode_preR13_section_hdr ("LTYPE", SECTION_LTYPE, dat, dwg)
        || decode_preR13_section_hdr ("VIEW", SECTION_VIEW, dat, dwg))
```
and it leads to heap buffer write overlow in `decode_preR13_section_hdr` when id is `SECTION_LAYER`.
```cpp
Dwg_Section *tbl = &dwg->header.section[id];
strncpy (tbl->name, name, 63);
```