### PR TITLE
Fixes Heap-buffer-overflow in dwg_decode_MINSERT_private

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -55,13 +55,14 @@ void
 bit_advance_position (Bit_Chain *dat, long advance)
 {
   const unsigned long pos  = bit_position (dat);
-  const unsigned long endpos = dat->size * 8;
+  const unsigned long endpos = dat->size * 8 - 1;
   long bits = (long)dat->bit + advance;
   if (pos + advance > endpos)
     {
       loglevel = dat->opts & DWG_OPTS_LOGLEVEL;
       LOG_ERROR ("%s buffer overflow at pos %lu.%u, size %lu, advance by %ld",
                  __FUNCTION__, dat->byte, dat->bit, dat->size, advance);
+      return;
     }
   else if ((long)pos + advance < 0)
     {


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31741 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31591

The out of bounds read happens in `TRACE_DD` macro at `dat->chain[dat->byte]` because of corrupted `dat->byte`: `dat->byte` equals to `dat->size`.
The corruption happens before in `bit_advance_position`. When `advance == 2`, `dat->size == 2`, `dat->byte == 1`, `dat->bit == 6` it calculates `pos == 14` and `endpos == 16`.
Then it passes the overflow check: `if (pos + advance > endpos)` and after
```cpp
  dat->byte += (bits >> 3);
  dat->bit = bits & 7;
```
`dat->byte` becomes 2.