### PR TITLE
Fixes Segv on unknown address in dwg_free_summaryinfo

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -1154,6 +1154,7 @@ dxf_header_read (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
                   dwg->summaryinfo.props
                     = (Dwg_SummaryInfo_Property*)realloc (dwg->summaryinfo.props,
                                  (j + 1) * sizeof (Dwg_SummaryInfo_Property));
+                  memset (dwg->summaryinfo.props + j, 0, sizeof (Dwg_SummaryInfo_Property));
                   LOG_TRACE ("SUMMARY.props[%u].tag = %s [TU16 1]\n", j,
                              pair->value.s);
                   dwg->summaryinfo.props[j].tag = bit_utf8_to_TU (pair->value.s, 0);


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33059

`dwg.summaryinfo.props[0].value` in `dwg_free_summaryinfo` is uninitialized pointer. It happens when `dwg_read_dxf` fails and partially initialized summary info object is created.