### PR TITLE
Fix various typos

### DIFF
--- a/doc/LibreDWG.texi
+++ b/doc/LibreDWG.texi
@@ -550,7 +550,7 @@ and contains all entities and objects. It is indexed by @ref{HANDLES}.
 @section CLASSES Section
 
 The @strong{Classes} Section contains the basic info for all dynamically loaded types for entities and objects.
-It's types start with 500, and are variable. An entity which has no class loaded is displayed as proxy.
+Its types start with 500, and are variable. An entity which has no class loaded is displayed as proxy.
 
 LibreDWG contains support for many classes, but not all. See @file{src/classes.inc} and @file{src/classes.c}.
 We define a stability for each class, one of stable, unstable, debugging and unhandled.
@@ -562,12 +562,12 @@ Only when rewriting from-to the very same version with the full known unknown_bi
 
 Objects in @strong{debugging} classes are only handled with the developer @code{configure --enable-debug} flag, otherwise ignored. See unstable above.
 
-Objects in @strong{undhandled} classes are always ignored. There are no fields known, only it's type.
+Objects in @strong{undhandled} classes are always ignored. There are no fields known, only its type.
 
 @node HANDLES
 @section HANDLES Section
 
-The Handles section contains a sorted list of all object handles and it's position in the Objects stream.
+The Handles section contains a sorted list of all object handles and its position in the Objects stream.
 All values are stored relatively, as offsets. Handles only increase and can contain holews when an object is deleted, offsets can jump back also.
 
 @node R2004_Header
@@ -628,7 +628,7 @@ RL
 @node Preview
 @section Preview
 
-The optional Preview section contains the thumbnail stream of BMP or WMF data of the drawing. Note that blocks or proxy objects can also contain it's own preview fields. The program @strong{dwgbmp} can extract the bitmap from this section.
+The optional Preview section contains the thumbnail stream of BMP or WMF data of the drawing. Note that blocks or proxy objects can also contain its own preview fields. The program @strong{dwgbmp} can extract the bitmap from this section.
 
 @node VBAProject
 @section VBAProject

--- a/src/dwg.c
+++ b/src/dwg.c
@@ -815,7 +815,7 @@ dwg_ref_object_relative (const Dwg_Data *restrict dwg,
 }
 
 /**
- * Find a pointer to an object given it's absolute id (handle).
+ * Find a pointer to an object given its absolute id (handle).
  * TODO: Check and update each handleref obj cache.
  * Note that absref 0 is illegal here, I think.
  */

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -2508,7 +2508,7 @@ static int encode_3dsolid (Bit_Chain* dat, Bit_Chain* hdl_dat,
               num_blocks = 1;
             }
           /* insecure. e.g. oss-fuzz issue 32165
-             all inouts: dwg, injson and indxf have correct num_blocks values
+             all inputs: dwg, injson and indxf have correct num_blocks values
           else if (!num_blocks)
             {
               num_blocks = 0;

--- a/src/encode.c
+++ b/src/encode.c
@@ -2276,7 +2276,7 @@ dwg_encode (Dwg_Data *restrict dwg, Bit_Chain *restrict dat)
 #endif
 
   bit_chain_alloc (dat);
-  hdl_dat = dat; // splitted later in objects/entities
+  hdl_dat = dat; // split later in objects/entities
   if (!dat->version)
     {
       dat->version = dwg->header.version;

--- a/test/test-data/2000/TS1.dwg.info
+++ b/test/test-data/2000/TS1.dwg.info
@@ -28,7 +28,7 @@ List of Objects in drawing file
 9.  Ordinate Dimension
 10. Aligned Dimension
 11. 3 point angular dimension
-12. Angular Dimansion
+12. Angular Dimension
 13. Diametric Dimension
 14. Radial Dimension
 15. 3D face

--- a/test/xmlsuite/check.py
+++ b/test/xmlsuite/check.py
@@ -89,10 +89,10 @@ for report in final_output:
 	reporthtm.write("\n<div class='attributedetail'><h3>Attribute Details</h3>\n")
 	for unmatched in report[3]:
 		if unmatched['duplicate'] == "":
-			reporthtm.write("\n<p><b>%s</b> wasn't found at all. It's value should be <b>%s</b></p>\n"
+			reporthtm.write("\n<p><b>%s</b> wasn't found at all. Its value should be <b>%s</b></p>\n"
 							% (unmatched['attrname'], unmatched['original']))
 		else:
-			reporthtm.write("\n<p><b>%s</b> didn't match. It's value should be <b>%s</b>, and it is <b>%s</b></p>\n"
+			reporthtm.write("\n<p><b>%s</b> didn't match. Its value should be <b>%s</b>, and it is <b>%s</b></p>\n"
 							%(unmatched['attrname'],
 							  unmatched["original"], unmatched['duplicate']))
 	reporthtm.write("</div>")

--- a/test/xmlsuite/common.c
+++ b/test/xmlsuite/common.c
@@ -14,9 +14,9 @@ xmlChar *doubletohex (double handle);
  *
  *  To emit this in the XML file
  *
- *  @param double x The X Co-ordinate
- *  @param double y The Y Co-ordinate
- *  @param double z The Z Co-ordinate
+ *  @param double x The X coordinate
+ *  @param double y The Y coordinate
+ *  @param double z The Z coordinate
  *
  *  @return xmlChar* Converted string in the specified pattern
  */
@@ -93,8 +93,8 @@ inttochar (int x)
  *
  * Format: (x y)
  *
- * @param double x The x co-ordinate of the point
- * @param double y The y co-ordinate of the point
+ * @param double x The x coordinate of the point
+ * @param double y The y coordinate of the point
  *
  * @return xmlChar* Returns the string in the given format. Return empty string
  * on error


### PR DESCRIPTION
Found via `codespell -q 3 -S ChangeLog,./NEWS -L 2rd,aadd,addd,aded,ba,childs,daa,ded,fo,gir,gost,noo,oce,ro,siz,tekst,ue`