### PR TITLE
Fix typos

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -1249,7 +1249,7 @@ bit_read_H (Bit_Chain *restrict dat, Dwg_Handle *restrict handle)
 
   // TODO: little-endian only
   // x86_64 gcc-9.[0-2] miscompilation with val[i]: (%rbx) being dat+1
-  // we work aorund this one, but you never know what else is being miscompiled.
+  // we work around this one, but you never know what else is being miscompiled.
   // apparently fixed in gcc-9.3, but 9.3 is still broken for cperl.
 #if defined(__GNUC__) && (__GNUC__ == 9) && (__GNUC_MINOR__ <= 2) \
   && (SIZEOF_SIZE_T == 8)                                         \

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3319,7 +3319,7 @@ DWG_OBJECT (LAYER)
     FIELD_B (locked, 0);
   }
   SINCE (R_2000) {
-    // seperate DXF flag 70 from the internal DWG flag0 bitmask
+    // separate DXF flag 70 from the internal DWG flag0 bitmask
     int flag0 = FIELD_VALUE (flag0);
     FIELD_BSx (flag0, 0); // -> 70,290,370
     flag0 = FIELD_VALUE (flag0);

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -6220,7 +6220,7 @@ new_table_control (const char *restrict name, Bit_Chain *restrict dat,
   char *fieldname;
   char ctrlname[80];
   char *dxfname;
-  BITCODE_B is_xref_ref; // referencable
+  BITCODE_B is_xref_ref; // referenceable
 
   NEW_OBJECT (dwg, obj);
 

--- a/test/test-data/2000/TS1.dwg.info
+++ b/test/test-data/2000/TS1.dwg.info
@@ -35,7 +35,7 @@ List of Objects in drawing file
 16. Polygon Mesh
 17. 3D Solid
 18. Trace
-19. Elipse
+19. Ellipse
 20. Spline
 21. Region
 22. Ray


### PR DESCRIPTION
Found via `codespell -q 3 -S ./.git,ChangeLog,./NEWS -L 2rd,aadd,addd,aded,afe,ba,baed,beed,childs,daa,ded,ede,fo,gir,gost,nam,noo,oce,ro,siz,tekst,ue,uptodate`