### PR TITLE
Fix log in free mode

### DIFF
--- a/src/common_entity_data.spec
+++ b/src/common_entity_data.spec
@@ -40,8 +40,10 @@
 #elif defined IS_JSON
         //KEY (size); VALUE_RS (obj->size, 0);
 #endif
-        LOG_TRACE("size: %d [RS]", obj->size);
-        LOG_POS
+        DECODER_OR_ENCODER {
+          LOG_TRACE("size: %d [RS]", obj->size);
+          LOG_POS
+        }
         FIELD_HANDLE (layer, 2, 8);
       }
       FIELD_RSx (opts_r11, 0); // i.e. dataflags


### PR DESCRIPTION
There were information like ```size: 30 [RC]``` in log of free section