### PR TITLE
Fix version of AutoCAD for preR13 entity types

### DIFF
--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -22260,7 +22260,7 @@ dwg_add_u8_input (Dwg_Data *restrict dwg, const char *restrict u8str)
         }
       return tgt;
 #  endif
-      if (dwg->header.version <= R_11 && strlen (u8str) < 32)
+      if (dwg->header.version <= R_12 && strlen (u8str) < 32)
         {
           // those old names are usually 32byte, and bit_write_TF
           // might heap-overflow then.
@@ -22705,7 +22705,7 @@ dwg_add_Document (Dwg_Data *restrict dwg, const int imperial)
   {
     // BLOCK: (5.1.24)
     Dwg_Entity_BLOCK *block = dwg_add_BLOCK (mspace, "*MODEL_SPACE");
-    if (dwg->header.version <= R_11) // fixup the type
+    if (dwg->header.version <= R_12) // fixup the type
       {
         obj = dwg_obj_generic_to_object (block, &error);
         obj->type = DWG_TYPE_UNUSED_R11; // don't encode it
@@ -22714,7 +22714,7 @@ dwg_add_Document (Dwg_Data *restrict dwg, const int imperial)
   {
     // ENDBLK: (5.1.25)
     Dwg_Entity_ENDBLK *endblk = dwg_add_ENDBLK (mspace);
-    if (dwg->header.version <= R_11) // fixup the type
+    if (dwg->header.version <= R_12) // fixup the type
       {
         obj = dwg_obj_generic_to_object (endblk, &error);
         obj->type = DWG_TYPE_UNUSED_R11; // don't encode it
@@ -23105,7 +23105,7 @@ dwg_add_TEXT (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   if (dwg->header_vars.TEXTSTYLE)
     _obj->style = dwg_add_handleref (
         dwg, 5, dwg->header_vars.TEXTSTYLE->absolute_ref, NULL);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_TEXT_R11;
       if (_obj->elevation == 0.0)
@@ -23248,7 +23248,7 @@ dwg_add_ATTRIB (Dwg_Entity_INSERT *restrict insert, const double height,
   insert->has_attribs = 1;
   // TODO: if !blkhdr->hasattrs: error no ATTDEF
   insert->block_header = dwg_add_handleref (dwg, 3, blkobj->handle.value, insobj);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_ATTRIB_R11;
       if (_obj->elevation == 0.0)
@@ -23293,7 +23293,7 @@ dwg_add_ATTDEF (Dwg_Object_BLOCK_HEADER *restrict blkhdr, const double height,
     _obj->style = dwg_add_handleref (
         dwg, 5, dwg->header_vars.TEXTSTYLE->absolute_ref, NULL);
   blkhdr->hasattrs = 1;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_ATTDEF_R11;
       if (_obj->elevation == 0.0)
@@ -23307,7 +23307,7 @@ dwg_add_BLOCK (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
                const char *restrict name)
 {
   API_ADD_ENTITY (BLOCK);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     obj->type = DWG_TYPE_BLOCK_R11;
   _obj->name = dwg_add_u8_input (dwg, name);
   return _obj;
@@ -23317,7 +23317,7 @@ EXPORT Dwg_Entity_ENDBLK *
 dwg_add_ENDBLK (Dwg_Object_BLOCK_HEADER *restrict blkhdr)
 {
   API_ADD_ENTITY (ENDBLK);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     obj->type = DWG_TYPE_ENDBLK_R11;
   dwg_fixup_BLOCKS_entities (dwg);
   return _obj;
@@ -23328,7 +23328,7 @@ EXPORT Dwg_Entity_SEQEND *
 dwg_add_SEQEND (dwg_ent_generic *restrict blkhdr)
 {
   API_ADD_ENTITY (SEQEND);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     obj->type = DWG_TYPE_SEQEND_R11;
   return _obj;
 }
@@ -23375,7 +23375,7 @@ dwg_add_INSERT (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
     }
   if (dwg->header.version < R_2_0b)
     _obj->block_name = strdup (name);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_INSERT_R11;
       if (_obj->ins_pt.z == 0.0)
@@ -23433,7 +23433,7 @@ dwg_add_MINSERT (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
       blkhdr->inserts[blkhdr->num_inserts - 1]
           = dwg_add_handleref (dwg, 4, obj->handle.value, NULL);
     }
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_INSERT_R11;
       if (_obj->ins_pt.z == 0.0)
@@ -23459,7 +23459,7 @@ dwg_add_VERTEX_2D (Dwg_Entity_POLYLINE_2D *restrict pline,
   _obj->point.x = point->x;
   _obj->point.y = point->y;
   _obj->flag = 0x20;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_VERTEX_R11;
       if (_obj->point.z == 0.0)
@@ -23485,7 +23485,7 @@ dwg_add_VERTEX_3D (Dwg_Entity_POLYLINE_3D *restrict pline,
   _obj->point.y = point->y;
   _obj->point.z = point->z;
   _obj->flag = 0x20;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_VERTEX_R11;
       if (_obj->point.z == 0.0)
@@ -23551,7 +23551,7 @@ dwg_add_POLYLINE_2D (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _pl->seqend
       = dwg_add_handleref (dwg, 3, dwg_obj_generic_handlevalue (_seq), pl);
   pl->tio.entity->next_entity = NULL;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     obj->type = DWG_TYPE_POLYLINE_R11;
 
   _pl->num_owned = num_pts;
@@ -23613,7 +23613,7 @@ dwg_add_POLYLINE_3D (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _pl->seqend
       = dwg_add_handleref (dwg, 3, dwg_obj_generic_handlevalue (_seq), pl);
   pl->tio.entity->next_entity = NULL;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     obj->type = DWG_TYPE_POLYLINE_R11;
 
   _pl->num_owned = num_pts;
@@ -23634,7 +23634,7 @@ dwg_add_VERTEX_PFACE (Dwg_Entity_POLYLINE_PFACE *restrict pline,
   _obj->point.x = point->x;
   _obj->point.y = point->y;
   _obj->point.z = point->z;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_VERTEX_R11;
       obj->tio.entity->opts_r11 = OPTS_R11_VERTEX_HAS_FLAG;
@@ -23657,7 +23657,7 @@ dwg_add_VERTEX_PFACE_FACE (Dwg_Entity_POLYLINE_PFACE *restrict pline,
   _obj->vertind[1] = vertind[1];
   _obj->vertind[2] = vertind[2];
   _obj->vertind[3] = vertind[3];
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_VERTEX_R11;
       obj->tio.entity->flag_r11 = 128;
@@ -23742,7 +23742,7 @@ dwg_add_POLYLINE_PFACE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
       = dwg_add_handleref (dwg, 3, dwg_obj_generic_handlevalue (_seq), pl);
   IN_POSTPROCESS_SEQEND (obj, _pl->num_owned, _pl->vertex);
   pl->tio.entity->next_entity = NULL; // fixup
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     obj->type = DWG_TYPE_POLYLINE_R11;
   return _pl;
 }
@@ -23760,7 +23760,7 @@ dwg_add_VERTEX_MESH (Dwg_Entity_POLYLINE_MESH *restrict pline,
   _obj->point.x = point->x;
   _obj->point.y = point->y;
   _obj->point.z = point->z;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_VERTEX_R11;
       //obj->tio.entity->flag_r11 = 0;
@@ -23830,7 +23830,7 @@ dwg_add_POLYLINE_MESH (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _pl->seqend
       = dwg_add_handleref (dwg, 3, dwg_obj_generic_handlevalue (_seq), pl);
   pl->tio.entity->next_entity = NULL;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_POLYLINE_R11;
       obj->tio.entity->opts_r11 = OPTS_R11_POLYLINE_HAS_FLAG;
@@ -23860,7 +23860,7 @@ dwg_add_ARC (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->end_angle = end_angle;
   ADD_CHECK_ANGLE (_obj->start_angle);
   ADD_CHECK_ANGLE (_obj->end_angle);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_ARC_R11;
       if (_obj->center.z == 0.0)
@@ -23879,7 +23879,7 @@ dwg_add_CIRCLE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->center.y = center->y;
   _obj->center.z = center->z;
   _obj->radius = radius;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_CIRCLE_R11;
       // UNTESTED
@@ -23921,7 +23921,7 @@ dwg_add_LINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
           obj->tio.entity->opts_r11 |= 2;
         }
     }
-  if (dwg->header.version >= R_10 && dwg->header.version <= R_11)
+  if (dwg->header.version >= R_10 && dwg->header.version <= R_12)
     {
       if (_obj->start.z != 0.0 || _obj->end.z != 0.0)
         {
@@ -23984,7 +23984,7 @@ dwg_add_DIMENSION_ALIGNED (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->xline2_pt.y = xline2_pt->y;
   _obj->xline2_pt.z = xline2_pt->z;
   // TODO calc oblique_angle
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_DIMENSION_R11;
       obj->tio.entity->flag_r11 = 64 + FLAG_R11_DIMENSION_ALIGNED;
@@ -24024,7 +24024,7 @@ dwg_add_DIMENSION_ANG2LN (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->xline2end_pt.x = xline2end_pt->x;
   _obj->xline2end_pt.y = xline2end_pt->y;
   _obj->xline2end_pt.z = xline2end_pt->z;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_DIMENSION_R11;
       obj->tio.entity->flag_r11 = 64 + FLAG_R11_DIMENSION_ANG2LN;
@@ -24063,7 +24063,7 @@ dwg_add_DIMENSION_ANG3PT (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->xline2_pt.x = xline2_pt->x;
   _obj->xline2_pt.y = xline2_pt->y;
   _obj->xline2_pt.z = xline2_pt->z;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_DIMENSION_R11;
       obj->tio.entity->flag_r11 = 64 + FLAG_R11_DIMENSION_ANG3PT;
@@ -24095,7 +24095,7 @@ dwg_add_DIMENSION_DIAMETER (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->first_arc_pt.y = chord_pt->y;
   _obj->first_arc_pt.z = chord_pt->z;
   _obj->leader_len = leader_len;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_DIMENSION_R11;
       obj->tio.entity->flag_r11 = 64 + FLAG_R11_DIMENSION_DIAMETER;
@@ -24126,7 +24126,7 @@ dwg_add_DIMENSION_ORDINATE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->leader_endpt.y = leader_endpt->y;
   _obj->leader_endpt.z = leader_endpt->z;
   _obj->flag2 = (BITCODE_RC)use_x_axis;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_DIMENSION_R11;
       obj->tio.entity->flag_r11 = 64 + FLAG_R11_DIMENSION_ORDINATE;
@@ -24158,7 +24158,7 @@ dwg_add_DIMENSION_RADIUS (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->first_arc_pt.y = chord_pt->y;
   _obj->first_arc_pt.z = chord_pt->z;
   _obj->leader_len = leader_len;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_DIMENSION_R11;
       obj->tio.entity->flag_r11 = 64 + FLAG_R11_DIMENSION_RADIUS;
@@ -24196,7 +24196,7 @@ dwg_add_DIMENSION_LINEAR (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->dim_rotation = rotation_angle;
   ADD_CHECK_ANGLE (_obj->dim_rotation);
   // TODO calc oblique_angle
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_DIMENSION_R11;
       obj->tio.entity->flag_r11 = 64 + FLAG_R11_DIMENSION_LINEAR;
@@ -24213,7 +24213,7 @@ dwg_add_POINT (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->x = pt->x;
   _obj->y = pt->y;
   _obj->z = pt->z;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_POINT_R11;
       if (_obj->z == 0.0)
@@ -24277,7 +24277,7 @@ dwg_add_3DFACE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
       _obj->z_is_zero = 1;
       obj->tio.entity->flag_r11 |= FLAG_R11_HAS_ELEVATION;
     }
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     obj->type = DWG_TYPE_3DFACE_R11;
 
   _obj->has_no_flags = 1; // set invis_flags extra
@@ -24305,7 +24305,7 @@ dwg_add_SOLID (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->corner3.y = pt3->y;
   _obj->corner4.x = pt4->x;
   _obj->corner4.y = pt4->y;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_SOLID_R11;
       if (_obj->elevation != 0.0)
@@ -24335,7 +24335,7 @@ dwg_add_TRACE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->corner3.y = pt3->y;
   _obj->corner4.x = pt4->x;
   _obj->corner4.y = pt4->y;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_TRACE_R11;
       if (_obj->elevation == 0.0)
@@ -24367,7 +24367,7 @@ dwg_add_SHAPE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
     }
   else
     _obj->style_id = 1; // Standard
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
       obj->type = DWG_TYPE_SHAPE_R11;
       if (_obj->ins_pt.z == 0.0)
@@ -24381,7 +24381,7 @@ dwg_add_VIEWPORT (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
                   const char *restrict name)
 {
   API_ADD_ENTITY (VIEWPORT);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version < R_11)
     {
       LOG_ERROR ("Invalid entity %s <r11", "VIEWPORT")
       API_UNADD_ENTITY;
@@ -24403,7 +24403,7 @@ dwg_add_VIEWPORT (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   _obj->UCSVP = 1;
   _obj->ucsxdir.x = 1.0;
   _obj->ucsydir.y = 1.0;
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     obj->type = DWG_TYPE_VIEWPORT_R11;
   return _obj;
 }
@@ -24414,9 +24414,9 @@ dwg_add_ELLIPSE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
                  const double axis_ratio)
 {
   API_ADD_ENTITY (ELLIPSE);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "3DSOLID")
+      LOG_ERROR ("Invalid entity %s <r13", "3DSOLID")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24452,9 +24452,9 @@ dwg_add_SPLINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
                 const dwg_point_3d *restrict end_tan_vec)
 {
   API_ADD_ENTITY (SPLINE);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "3DSOLID")
+      LOG_ERROR ("Invalid entity %s <r13", "SPLINE")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24481,9 +24481,9 @@ dwg_add_REGION (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   unsigned j;
   int acis_data_idx = 0;
   API_ADD_ENTITY (REGION);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "3DSOLID")
+      LOG_ERROR ("Invalid entity %s <r13", "REGION")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24517,9 +24517,9 @@ dwg_add_3DSOLID (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   unsigned j;
   int acis_data_idx = 0;
   API_ADD_ENTITY (_3DSOLID);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "3DSOLID")
+      LOG_ERROR ("Invalid entity %s <r13", "_3DSOLID")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24554,9 +24554,9 @@ dwg_add_BODY (Dwg_Object_BLOCK_HEADER *restrict blkhdr, const char *acis_data)
   unsigned j;
   int acis_data_idx = 0;
   API_ADD_ENTITY (BODY);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "BODY")
+      LOG_ERROR ("Invalid entity %s <r13", "BODY")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24588,9 +24588,9 @@ dwg_add_RAY (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
              const dwg_point_3d *restrict vector) /* different to VBA */
 {
   API_ADD_ENTITY (RAY);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "RAY")
+      LOG_ERROR ("Invalid entity %s <r13", "RAY")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24609,9 +24609,9 @@ dwg_add_XLINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
                const dwg_point_3d *restrict vector) /* different to VBA */
 {
   API_ADD_ENTITY (XLINE);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "XLINE")
+      LOG_ERROR ("Invalid entity %s <r13", "XLINE")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24787,9 +24787,9 @@ dwg_add_OLE2FRAME (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
 {
   // const Dwg_Object_Ref *pspace =  dwg_paper_space_ref (dwg);
   API_ADD_ENTITY (OLE2FRAME);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "OLE2FRAME")
+      LOG_ERROR ("Invalid entity %s <r13", "OLE2FRAME")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24847,9 +24847,9 @@ dwg_add_LEADER (
       API_UNADD_ENTITY;
       return NULL;
     }
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "LEADER")
+      LOG_ERROR ("Invalid entity %s <r13", "LEADER")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24920,9 +24920,9 @@ dwg_add_TOLERANCE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
 {
   API_ADD_ENTITY (TOLERANCE);
   _obj->text_value = dwg_add_u8_input (dwg, text_value);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "TOLERANCE")
+      LOG_ERROR ("Invalid entity %s <r13", "TOLERANCE")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -24952,9 +24952,9 @@ dwg_add_MLINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
   BITCODE_H mlstyref;
   Dwg_Object_MLINESTYLE *mlstyle = NULL;
   API_ADD_ENTITY (MLINE);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "MLINE")
+      LOG_ERROR ("Invalid entity %s <r13", "MLINE")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -25304,9 +25304,9 @@ dwg_add_GROUP (Dwg_Data *restrict dwg,
   Dwg_Object_Ref *groupdict;
   Dwg_Object *nod = dwg_get_first_object (dwg, DWG_TYPE_DICTIONARY);
   API_ADD_OBJECT (GROUP);
-  if (dwg->header.version <= R_11)
+  if (dwg->header.version <= R_12)
     {
-      LOG_ERROR ("Invalid entity %s <r11", "GROUP")
+      LOG_ERROR ("Invalid entity %s <r13", "GROUP")
       API_UNADD_ENTITY;
       return NULL;
     }
@@ -25411,9 +25411,9 @@ dwg_add_LWPOLYLINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
     Dwg_Data *dwg = hdr ? hdr->parent : NULL;
     if (dwg && dwg->header.version < R_2000)
       REQUIRE_CLASS ("LWPOLYLINE");
-    if (dwg && dwg->header.version <= R_11)
+    if (dwg && dwg->header.version <= R_12)
       {
-        LOG_ERROR ("Invalid entity %s <r11", "LWPOLYLINE")
+        LOG_ERROR ("Invalid entity %s <r13", "LWPOLYLINE")
         return NULL;
       }
   }
@@ -25438,9 +25438,9 @@ dwg_add_HATCH (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
     Dwg_Data *dwg = hdr ? hdr->parent : NULL;
     if (dwg && dwg->header.version < R_2000)
       REQUIRE_CLASS ("HATCH");
-    if (dwg && dwg->header.version <= R_11)
+    if (dwg && dwg->header.version <= R_12)
       {
-        LOG_ERROR ("Invalid entity %s <r11", "HATCH")
+        LOG_ERROR ("Invalid entity %s <r13", "HATCH")
         return NULL;
       }
   }


### PR DESCRIPTION
Fix extracted from https://github.com/LibreDWG/libredwg/commits/work/r11-pline
It's independent of POLYLINE/VERTEX rewrite for preR13

New fixes:
* VIEWPORT is in R11
* Fix comments → <r13
* Fix logging (REGION, SPLINE)