### PR TITLE
error: ‘__builtin_strncat’ output truncated before terminating nul co…

### DIFF
--- a/src/header_variables_r11.spec
+++ b/src/header_variables_r11.spec
@@ -161,7 +161,7 @@
 #endif
   DECODER {    
     if (_obj->MENUEXT[1]) {
-      size_t len = strlen ((char*)&_obj->MENUEXT[1]);
+      size_t len = strlen ((char*)&_obj->MENUEXT[1]) + 1;
       _obj->MENU = (char*)realloc (_obj->MENU, strlen (_obj->MENU) + len + 1);
       strncat (_obj->MENU, (char*)&_obj->MENUEXT[1], len);
       LOG_TRACE ("MENU => \"%s\"\n", _obj->MENU);


### PR DESCRIPTION
…pying as many bytes from a string as its length [-Werror=stringop-truncation]

header_variables_r11.spec:164:20: note: length computed here
164 |       size_t len = strlen ((char*)&_obj->MENUEXT[1]);