### PR TITLE
dwg2SVG: define `_GNU_SOURCE` to expose `strcasestr` with musl libc

### DIFF
--- a/programs/dwg2SVG.c
+++ b/programs/dwg2SVG.c
@@ -40,6 +40,7 @@
 #    define __BSD_VISIBLE 1
 #  endif
 #endif
+#define _GNU_SOURCE  /* make musl expose strcasestr */
 #include <string.h>
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>


### PR DESCRIPTION
0.12.5.6248 built with gcc 12 and musl libc currently fails with:

```
dwg2SVG.c: In function 'output_TEXT':
dwg2SVG.c:245:10: error: implicit declaration of function 'strcasestr'; did you mean 'strcasecmp'? [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Werror=implicit-function-declaration8;;]
  245 |       && strcasestr (style->font_file, ".ttf")
      |          ^~~~~~~~~~
      |          strcasecmp
```

This is because the definition for `strcasestr` is hidden behind a `_GNU_SOURCE` ifdef in musl's `string.h`. Don't ask me why.

This resolves that for me.