### PR TITLE
Fix leader hook line flag

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3406,10 +3406,9 @@ DWG_ENTITY (LEADER)
   FIELD_BD (box_width, 0);
   FIELD_B (hookline_dir, 0); // if hook line is on x direction
   FIELD_B (arrowhead_on, 0);
-  //ENCODER {
-  //  if (FIELD_VALUE (hookline_on))
-  //    FIELD_VALUE(arrowhead_type) |= 8;
-  //}
+  ENCODER {
+    HANDLE_HOOKLINE_FLAG(hookline_on, FIELD_VALUE(num_points), FIELD_VALUE(points), FIELD_VALUE(annot_type), FIELD_VALUE(path_type));
+  }
   FIELD_BSx (arrowhead_type, 0);
   DECODER {
     HANDLE_HOOKLINE_FLAG(hookline_on, FIELD_VALUE(num_points), FIELD_VALUE(points), FIELD_VALUE(annot_type), FIELD_VALUE(path_type));

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -22,7 +22,6 @@
  * modified by Gian Maria Gentilini
  */
 
-#include <math.h>
 #include "spec.h"
 
 /* (1/7) */
@@ -3413,24 +3412,7 @@ DWG_ENTITY (LEADER)
   //}
   FIELD_BSx (arrowhead_type, 0);
   DECODER {
-    // Note that ODA doesn't spec it
-    // ODA's code does take bit 1 from path_type instead
-    //
-    // Hook lines appears if the last leader line segment is at an angle greater than 15 degrees from horizontal. 
-    // If the leader has no annotation or a spline path (?), it has no hook line.
-
-    const double hookline_offsetR = M_PI / 12;
-    double angleR = M_PI / 2;
-
-    if(FIELD_VALUE (num_points) > 2)
-    {
-      BITCODE_3DPOINT pt1 = FIELD_VALUE (points)[FIELD_VALUE (num_points) - 2];
-      BITCODE_3DPOINT pt2 = FIELD_VALUE (points)[FIELD_VALUE (num_points) - 1];
-      
-      angleR = atan2(pt1.y - pt2.y, pt1.x - pt2.x);
-    }
-
-    FIELD_VALUE (hookline_on) = (FIELD_VALUE (annot_type) & 0x3 || FIELD_VALUE (path_type) & 0x1 || fabs(angleR) <= hookline_offsetR || fabs(angleR - M_PI) <= hookline_offsetR) ? 0 : 1;
+    HANDLE_HOOKLINE_FLAG(hookline_on, FIELD_VALUE(num_points), FIELD_VALUE(points), FIELD_VALUE(annot_type), FIELD_VALUE(path_type));
     LOG_TRACE("hookline_on: %d [B 75] (calc)", FIELD_VALUE (hookline_on));
   }
   JSON {

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3412,7 +3412,7 @@ DWG_ENTITY (LEADER)
   FIELD_BSx (arrowhead_type, 0);
   DECODER {
     HANDLE_HOOKLINE_FLAG(hookline_on, FIELD_VALUE(num_points), FIELD_VALUE(points), FIELD_VALUE(annot_type), FIELD_VALUE(path_type));
-    LOG_TRACE("hookline_on: %d [B 75] (calc)", FIELD_VALUE (hookline_on));
+    LOG_TRACE("hookline_on: %d [B 75] (calc)\n", FIELD_VALUE (hookline_on));
   }
   JSON {
     FIELD_B (hookline_on, 0);

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -19,10 +19,11 @@
  * modified by Reini Urban
  * modified by Denis Pruchkovsky
  * modified by Michal Josef Špaček
+ * modified by Gian Maria Gentilini
  */
 
+#include <math.h>
 #include "spec.h"
-#include "math.h"
 
 /* (1/7) */
 DWG_ENTITY (TEXT)
@@ -3406,16 +3407,16 @@ DWG_ENTITY (LEADER)
   FIELD_BD (box_width, 0);
   FIELD_B (hookline_dir, 0); // if hook line is on x direction
   FIELD_B (arrowhead_on, 0);
-//  ENCODER {
-//    if (FIELD_VALUE (hookline_on))
-//      FIELD_VALUE(arrowhead_type) |= 8;
-// }
+  //ENCODER {
+  //  if (FIELD_VALUE (hookline_on))
+  //    FIELD_VALUE(arrowhead_type) |= 8;
+  //}
   FIELD_BSx (arrowhead_type, 0);
   DECODER {
     // Note that ODA doesn't spec it
     // ODA's code does take bit 1 from path_type instead
     //
-    // Hook lines appears if the last leader line segment is at an angle greater than 15 Degrees from horizontal. 
+    // Hook lines appears if the last leader line segment is at an angle greater than 15 degrees from horizontal. 
     // If the leader has no annotation or a spline path (?), it has no hook line.
 
     const double hookline_offsetR = M_PI / 12;
@@ -3423,14 +3424,14 @@ DWG_ENTITY (LEADER)
 
     if(FIELD_VALUE (num_points) > 2)
     {
-      BITCODE_3DPOINT pt1 = FIELD_VALUE (points)[FIELD_VALUE (num_points) - 1];
-      BITCODE_3DPOINT pt2 = FIELD_VALUE (points)[FIELD_VALUE (num_points) - 2];
+      BITCODE_3DPOINT pt1 = FIELD_VALUE (points)[FIELD_VALUE (num_points) - 2];
+      BITCODE_3DPOINT pt2 = FIELD_VALUE (points)[FIELD_VALUE (num_points) - 1];
       
       angleR = atan2(pt1.y - pt2.y, pt1.x - pt2.x);
     }
 
     FIELD_VALUE (hookline_on) = (FIELD_VALUE (annot_type) & 0x3 || FIELD_VALUE (path_type) & 0x1 || fabs(angleR) <= hookline_offsetR || fabs(angleR - M_PI) <= hookline_offsetR) ? 0 : 1;
-    LOG_TRACE("=> hookline_on: %d [B 75] => angle: %f\n", FIELD_VALUE (hookline_on), angleR);
+    LOG_TRACE("hookline_on: %d [B 75] (calc)", FIELD_VALUE (hookline_on));
   }
   JSON {
     FIELD_B (hookline_on, 0);

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -22,6 +22,7 @@
  */
 
 #include "spec.h"
+#include "math.h"
 
 /* (1/7) */
 DWG_ENTITY (TEXT)
@@ -3405,16 +3406,31 @@ DWG_ENTITY (LEADER)
   FIELD_BD (box_width, 0);
   FIELD_B (hookline_dir, 0); // if hook line is on x direction
   FIELD_B (arrowhead_on, 0);
-  ENCODER {
-    if (FIELD_VALUE (hookline_on))
-      FIELD_VALUE(arrowhead_type) |= 8;
-  }
+//  ENCODER {
+//    if (FIELD_VALUE (hookline_on))
+//      FIELD_VALUE(arrowhead_type) |= 8;
+// }
   FIELD_BSx (arrowhead_type, 0);
   DECODER {
-    // Note that ODA doesn't spec it, and ODA's code does
-    // take bit 1 from path_type instead
-    FIELD_VALUE (hookline_on) = FIELD_VALUE (arrowhead_type) & 8 ? 0 : 1;
-    LOG_TRACE("=> hookline_on: %d [B 75]\n", FIELD_VALUE (hookline_on));
+    // Note that ODA doesn't spec it
+    // ODA's code does take bit 1 from path_type instead
+    //
+    // Hook lines appears if the last leader line segment is at an angle greater than 15 Degrees from horizontal. 
+    // If the leader has no annotation or a spline path (?), it has no hook line.
+
+    const double hookline_offsetR = M_PI / 12;
+    double angleR = M_PI / 2;
+
+    if(FIELD_VALUE (num_points) > 2)
+    {
+      BITCODE_3DPOINT pt1 = FIELD_VALUE (points)[FIELD_VALUE (num_points) - 1];
+      BITCODE_3DPOINT pt2 = FIELD_VALUE (points)[FIELD_VALUE (num_points) - 2];
+      
+      angleR = atan2(pt1.y - pt2.y, pt1.x - pt2.x);
+    }
+
+    FIELD_VALUE (hookline_on) = (FIELD_VALUE (annot_type) & 0x3 || FIELD_VALUE (path_type) & 0x1 || fabs(angleR) <= hookline_offsetR || fabs(angleR - M_PI) <= hookline_offsetR) ? 0 : 1;
+    LOG_TRACE("=> hookline_on: %d [B 75] => angle: %f\n", FIELD_VALUE (hookline_on), angleR);
   }
   JSON {
     FIELD_B (hookline_on, 0);


### PR DESCRIPTION
Implements a calculation method aligned with AutoCAD's hook lines display rules, it remains unclear if the flag is actually stored somewhere.

Reference documentation:

* AutoCAD Official Documentation: [link](https://help.autodesk.com/view/ACDMAC/2018/ENU/index.html?guid=GUID-BC466DEE-ACD8-419A-B017-AB3065336AD7)
* AutoCAD ActiveX API Reference: [link](https://documentation.help/AutoCAD-ActiveX-AAG/WS1a9193826455f5ff1a32d8d10ebc6b7ccc-6b57.htm)

Hook lines appear if the last leader line segment is at an angle greater than 15 degrees from horizontal. 
If the leader has no annotations or a spline path (?), it is certain that hook lines are not displayed.