### PR TITLE
fix GEODATA num pts

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -4432,7 +4432,6 @@ add_GEODATA (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
                      o->geomesh_pts[i].source_pt.x, pair->value.d, 13);
           break;
         case 14:
-          i++;
           CHK_geomesh_pts;
           o->geomesh_pts[i].dest_pt.x = pair->value.d;
           break;


### PR DESCRIPTION
GEOMESH pts are a pair of coordinates, but the count was incorrectly increased for each, i.e. counting double.
It caused an invalid DWG error without log message.
This fixes it.
Bug and testfile is described in #875
