### PR TITLE
No JSON whitespace in release version

### DIFF
--- a/src/2ndheader.spec
+++ b/src/2ndheader.spec
@@ -24,7 +24,7 @@ VERSIONS (R_13, R_2000) {
   FIELD_TFF (version, 6, 0);
 #ifdef IS_JSON
   KEY (zero_5);
-  fprintf (dat->fh, "[ %d, %d, %d, %d, %d ]",
+  fprintf (dat->fh, "[" JSON_SPACE "%d," JSON_SPACE "%d," JSON_SPACE "%d," JSON_SPACE "%d," JSON_SPACE "%d" JSON_SPACE "]",
           _obj->zero_5[0], _obj->zero_5[1], _obj->zero_5[2], _obj->zero_5[3],
           _obj->zero_5[4]);
 #else

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3165,7 +3165,7 @@ DWG_OBJECT (DICTIONARY)
       {
         FIRSTPREFIX
         VALUE_T (_obj->texts[rcount1]);
-        fprintf (dat->fh, ": ");
+        fprintf (dat->fh, ":" JSON_SPACE);
         VALUE_HANDLE (_obj->itemhandles[rcount1], itemhandles, 2, 350);
       }
   }
@@ -3228,7 +3228,7 @@ DWG_OBJECT (DICTIONARYWDFLT)
       {
         FIRSTPREFIX
         VALUE_T (_obj->texts[rcount1]);
-        fprintf (dat->fh, ": ");
+        fprintf (dat->fh, ":" JSON_SPACE);
         VALUE_HANDLE (_obj->itemhandles[rcount1], itemhandles, 2, 350);
       }
   }

--- a/src/header.spec
+++ b/src/header.spec
@@ -21,7 +21,7 @@
 // char version[6] handled separately. older releases just had a version[12]
 #ifdef IS_JSON
   KEY (zero_5);
-  fprintf (dat->fh, "[ %d, %d, %d, %d, %d ]",
+  fprintf (dat->fh, "[" JSON_SPACE "%d," JSON_SPACE "%d," JSON_SPACE "%d," JSON_SPACE "%d," JSON_SPACE "%d" JSON_SPACE "]",
           _obj->zero_5[0], _obj->zero_5[1], _obj->zero_5[2], _obj->zero_5[3],
           _obj->zero_5[4]);
 #else


### PR DESCRIPTION
See #886 - (I didn't manage to rebase the original feature branch that I accidentally branched of another feature branch in reasonable time).

I considered this feature as a runtime option, but it would be more work and I don't know how to compile the c file twice to produce the same function with a different flag, without creating a mess.

I could however, make this as an optional DISABLE_JSON_WHITESPACE flag rather than default when DEBUG is not set.

IMHO a sleak release version by default is a more important use case, and therefore should not include unnecessary whitespace or conditionals.

JSON readability is for debugging and should be done by piping, autoformat, setting the flag, 2 variants of each program, or using the debug version.

YAML/JSON5 would more suitable for readability anyway, and could also be done with macro's in out_json, but someone else can do that.