### PR TITLE
Remove zero_5 variable

### DIFF
--- a/include/dwg.h
+++ b/include/dwg.h
@@ -9622,8 +9622,7 @@ typedef struct _dwg_secondheader
 {
   BITCODE_RL size;
   BITCODE_RL address;
-  BITCODE_RC version[7];
-  BITCODE_RC zero_5[5];
+  BITCODE_RC version[11];
   BITCODE_RC is_maint;
   BITCODE_RC zero_one_or_three;
   BITCODE_BS dwg_version;

--- a/include/dwg.h
+++ b/include/dwg.h
@@ -9356,7 +9356,6 @@ typedef struct _dwg_header
 {
   Dwg_Version_Type version;      /* calculated from the header magic */
   Dwg_Version_Type from_version; /* option. set by --as (convert from) */
-  BITCODE_RC zero_5[5];
   BITCODE_RC is_maint;
   BITCODE_RC zero_one_or_three;
   BITCODE_RS numentity_sections; /* < R13, always 3 */

--- a/src/2ndheader.spec
+++ b/src/2ndheader.spec
@@ -21,15 +21,7 @@
 VERSIONS (R_13, R_2000) {
   FIELD_RL (size, 0);
   FIELD_BL (address, 0);
-  FIELD_TFF (version, 6, 0);
-#ifdef IS_JSON
-  KEY (zero_5);
-  fprintf (dat->fh, "[ %d, %d, %d, %d, %d ]",
-          _obj->zero_5[0], _obj->zero_5[1], _obj->zero_5[2], _obj->zero_5[3],
-          _obj->zero_5[4]);
-#else
-  FIELD_VECTOR_INL (zero_5, RC, 5, 0)
-#endif
+  FIELD_TFF (version, 11, 0);
   FIELD_RC (is_maint, 0);
   FIELD_RC (zero_one_or_three, 0);
   FIELD_BSx (dwg_version, 0);

--- a/src/decode.c
+++ b/src/decode.c
@@ -125,7 +125,7 @@ static int objfreespace_private (Bit_Chain *restrict dat,
 EXPORT int
 dwg_decode (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
 {
-  char magic[8];
+  char magic[11];
 
   dwg->num_object_refs = 0;
   // dwg->num_layers = 0; // see now dwg->layer_control->num_entries
@@ -186,14 +186,8 @@ dwg_decode (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
       LOG_ERROR ("dwg too small: %" PRIuSIZE " bytes", dat->size);
       return DWG_ERR_INVALIDDWG;
     }
-  strncpy (magic, (const char *)dat->chain, 6);
-  if (memcmp (dat->chain, "AC103-4", 7) == 0)
-    {
-      magic[6] = '4';
-      magic[7] = '\0';
-    }
-  else
-    magic[6] = '\0';
+  strncpy (magic, (const char *)dat->chain, 11);
+  magic[10] = '\0';
 
   dwg->header.from_version = dwg_version_hdr_type (magic);
   if (!dwg->header.from_version)
@@ -216,6 +210,7 @@ dwg_decode (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
   LOG_INFO ("This file's version code is: %s (%s)\n", magic,
             dwg_version_type (dat->from_version))
 
+  dat->byte = 0xb; // After magic string.
   PRE (R_13b1)
   {
     Dwg_Object *ctrl;
@@ -319,7 +314,7 @@ decode_R13_R2000 (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
     Dwg_Header *_obj = &dwg->header;
     Bit_Chain *hdl_dat = dat;
     BITCODE_BL vcount;
-    dat->byte = 0x06;
+
     // clang-format off
     #include "header.spec"
     // clang-format on
@@ -3383,9 +3378,6 @@ decode_R2004 (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
     int i;
     BITCODE_BL vcount;
 
-    dat->byte = 0x06;
-    if (dat->from_version >= R_2022b)
-      dat->byte = 0x07;
     // clang-format off
     #include "header.spec"
     // clang-format on
@@ -3493,7 +3485,6 @@ decode_R2007 (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
     Dwg_Object *obj = NULL;
     BITCODE_BL vcount;
 
-    dat->byte = 0x06;
     // clang-format off
     #include "header.spec"
     // clang-format on

--- a/src/decode_r11.c
+++ b/src/decode_r11.c
@@ -636,7 +636,7 @@ decode_preR13 (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
     Dwg_Header *_obj = (Dwg_Header *)&dwg->header;
     // Bit_Chain *hdl_dat = dat;
     BITCODE_BL vcount;
-    dat->byte = 0x06;
+
     // clang-format off
     #include "header.spec"
     // clang-format on

--- a/src/encode.c
+++ b/src/encode.c
@@ -2624,7 +2624,7 @@ dwg_encode (Dwg_Data *restrict dwg, Bit_Chain *restrict dat)
    */
   strcpy ((char *)dat->chain,
           dwg_version_codes (dwg->header.version)); // Chain version
-  dat->byte += 6;
+  dat->byte += 11;
 
   {
     BITCODE_BL vcount;

--- a/src/encode.c
+++ b/src/encode.c
@@ -3618,8 +3618,6 @@ dwg_encode (Dwg_Data *restrict dwg, Bit_Chain *restrict dat)
           // TODO detect what it is
           _obj->junk_r14 = UINT64_C (0x989543D074AE8021);
         }
-      for (int k = 0; k < 5; k++)
-        _obj->zero_5[k] = dwg->header.zero_5[k];
       _obj->is_maint = dwg->header.is_maint;
       _obj->zero_one_or_three = dwg->header.zero_one_or_three;
       _obj->dwg_version

--- a/src/header.spec
+++ b/src/header.spec
@@ -18,15 +18,7 @@
 
 #include "spec.h"
 
-// char version[6] handled separately. older releases just had a version[12]
-#ifdef IS_JSON
-  KEY (zero_5);
-  fprintf (dat->fh, "[ %d, %d, %d, %d, %d ]",
-          _obj->zero_5[0], _obj->zero_5[1], _obj->zero_5[2], _obj->zero_5[3],
-          _obj->zero_5[4]);
-#else
-  FIELD_VECTOR_INL (zero_5, RC, 5, 0)
-#endif
+  // char version[11] handled separately
   FIELD_RC (is_maint, 0);
 
   VERSIONS (R_2_0b, R_13b1) {

--- a/src/in_json.c
+++ b/src/in_json.c
@@ -1078,15 +1078,6 @@ json_FILEHEADER (Bit_Chain *restrict dat, Dwg_Data *restrict dwg,
               return DWG_ERR_INVALIDDWG;
             }
         }
-      // FIELD_VECTOR_INL (zero_5, RL, 5, 0)
-      else if (strEQc (key, "zero_5") && t->type == JSMN_ARRAY)
-        {
-          tokens->index++;
-          for (int j = 0; j < MIN (5, t->size); j++)
-            {
-              _obj->zero_5[j] = json_long (dat, tokens);
-            }
-        }
       // clang-format off
       FIELD_RC (is_maint, 0)
       FIELD_RC (zero_one_or_three, 0)

--- a/src/in_json.c
+++ b/src/in_json.c
@@ -4134,8 +4134,7 @@ json_SecondHeader (Bit_Chain *restrict dat, Dwg_Data *restrict dwg,
       // clang-format off
       FIELD_RL (size, 0)
       FIELD_RL (address, 0)
-      FIELD_TFF (version, 6, 0)
-      FIELD_VECTOR_INL (zero_5, RC, 5, 0)
+      FIELD_TFF (version, 11, 0)
       FIELD_RC (is_maint, 0)
       FIELD_RC (zero_one_or_three, 0)
       FIELD_BS (dwg_version, 0)


### PR DESCRIPTION
This is about simplification of the header (and second header). It's for all DWG versions.