### PR TITLE
Use python3 syntax and modernize shebang env

### DIFF
--- a/examples/load_dwg.py
+++ b/examples/load_dwg.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python3
 
 #import libredwg
 from libredwg import *
@@ -15,7 +15,7 @@ a.object = new_Dwg_Object_Array(1000)
 error = dwg_read_file(filename, a)
 
 if (error > 0): # critical errors
-    print "Error: ", error
+    print("Error: ", error)
     if (error > 127):
         exit()
 


### PR DESCRIPTION
Many systems do not provide the /usr/bin/python link. Instead use the env program to specify a python3 working environment. Presumably during a conversion to python3, a print statement during an error check was still in python2 syntax, this is now changed to proper python3 syntax.