### PR TITLE
Remove maximum of classes

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -700,11 +700,6 @@ classes_section:
         dwg->layout_type = klass->number;
 
       dwg->num_classes++;
-      if (dwg->num_classes > 500)
-        {
-          LOG_ERROR ("number of classes is greater than 500");
-          break;
-        }
     }
 
   // Check Section CRC


### PR DESCRIPTION
I have a DWG file with more than 500 classes. After code in PR it's functional.