### PR TITLE
Fix spaces in logging of SPLINE scenario

### DIFF
--- a/src/spec.h
+++ b/src/spec.h
@@ -1169,7 +1169,7 @@
     {                                                                         \
       if (_obj->scenario)                                                     \
         {                                                                     \
-          LOG_TRACE ("         ");                                            \
+          LOG_TRACE ("          ");                                           \
           LOG_SPLINE_SCENARIO_W (SPLINE);                                     \
           LOG_SPLINE_SCENARIO_W (BEZIER);                                     \
           LOG_FLAG_MAX (_obj->scenario, 2);                                   \


### PR DESCRIPTION
Actually:
```
scenario: 2 [BL 0]
         BEZIER(0x2)
```

After:
```
scenario: 2 [BL 0]
          BEZIER(0x2)
```