### PR TITLE
Fix autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -15,7 +15,9 @@ set -x
 rm -rf autom4te.cache config.status
 if test -d .git -a -f build-aux/git-version-gen; then
     git fetch --tags
-    rm .tarball-version
+    if [ -f .tarball-version ]; then
+        rm .tarball-version
+    fi
     v=$(build-aux/git-version-gen .tarball-version)
     echo $v >.tarball-version
     echo $v >.version


### PR DESCRIPTION
There is situation after clone from git repository. .tarball-version doesn't exists in this time.