### PR TITLE
Improve angle logging

### DIFF
--- a/src/dec_macros.h
+++ b/src/dec_macros.h
@@ -144,6 +144,40 @@
       LOG_RPOS                                                                \
     }
 
+#define FIELD_G_TRACE_ANGLE(nam, type, dxfgroup)                              \
+  if (DWG_LOGLEVEL >= DWG_LOGLEVEL_TRACE)                                     \
+    {                                                                         \
+      char *s1 = strrplc (#nam, "[rcount1]", "[%d]");                         \
+      if (s1)                                                                 \
+        {                                                                     \
+          char *s2 = strrplc (s1, "[rcount2]", "[%d]");                       \
+          if (s2)                                                             \
+            {                                                                 \
+              GCC46_DIAG_IGNORE (-Wformat-nonliteral)                         \
+              LOG_TRACE (strcat (s2, ": " FORMAT_##type " [" #type            \
+                                 " %d] %gº"),                                 \
+                         rcount1, rcount2, _obj->nam, dxfgroup,               \
+                         rad2deg (_obj->nam));                                \
+              GCC46_DIAG_RESTORE                                              \
+              free (s2);                                                      \
+              free (s1);                                                      \
+            }                                                                 \
+          else                                                                \
+            {                                                                 \
+              GCC46_DIAG_IGNORE (-Wformat-nonliteral)                         \
+              LOG_TRACE (strcat (s1, ": " FORMAT_##type " [" #type            \
+                                 " %d] %gº"),                                 \
+                         rcount1, _obj->nam, dxfgroup, rad2deg (_obj->nam));  \
+              GCC46_DIAG_RESTORE                                              \
+              free (s1);                                                      \
+            }                                                                 \
+        }                                                                     \
+      else                                                                    \
+        LOG_TRACE (#nam ": " FORMAT_##type " [" #type " %d] %gº",             \
+                   (BITCODE_##type)_obj->nam, dxfgroup, rad2deg (_obj->nam)); \
+      LOG_RPOS                                                                \
+    }
+
 #define FIELD_TRACE(nam, type)                                                \
   if (DWG_LOGLEVEL >= DWG_LOGLEVEL_TRACE)                                     \
     {                                                                         \
@@ -453,9 +487,7 @@
       }                                                                       \
     if (dxf >= 50 && dxf < 54)                                                \
       {                                                                       \
-        LOG_TRACE (#nam ": " FORMAT_BD " [BD %d]  %gº", _obj->nam, dxf,       \
-                   rad2deg (_obj->nam));                                      \
-        LOG_RPOS                                                              \
+        FIELD_G_TRACE_ANGLE (nam, BD, dxf);                                   \
       }                                                                       \
     else                                                                      \
       {                                                                       \


### PR DESCRIPTION
Previous in LTYPE table:

dashes[3].length: -0.2 [BD 49]
dashes[3].complex_shapecode: 4 [BS 75]
dashes[rcount1].style: (5.1.10) abs:16 [H 340] => STYLE STANDARD dashes[3].x_offset: 0 [RD 44]
dashes[3].y_offset: 0 [RD 45]
dashes[3].scale: 0.1 [BD 46]
dashes[rcount1].rotation: 1.5708 [BD 50]  90º
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dashes[3].shape_flag: 3 [BS 74]
                      ABS_ROTATION(0x1) IS_TEXT(0x2)

After change:

dashes[3].length: -0.2 [BD 49]
dashes[3].complex_shapecode: 4 [BS 75]
dashes[rcount1].style: (5.1.10) abs:16 [H 340] => STYLE STANDARD dashes[3].x_offset: 0 [RD 44]
dashes[3].y_offset: 0 [RD 45]
dashes[3].scale: 0.1 [BD 46]
dashes[3].rotation: 1.5708 [BD 50] 90º
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dashes[3].shape_flag: 3 [BS 74]
                      ABS_ROTATION(0x1) IS_TEXT(0x2)