### PR TITLE
Fix $BLIPMODE in DXF output

### DIFF
--- a/src/header_variables_dxf.spec
+++ b/src/header_variables_dxf.spec
@@ -243,7 +243,7 @@
   }
   HEADER_RS (LIMCHECK, 70);
   UNTIL (R_14) {
-    HEADER_RS0 (BLIPMODE, 70); //documented but nowhere found
+    HEADER_RS (BLIPMODE, 70); //documented but nowhere found
   }
   HEADER_RD (CHAMFERA, 40);
   HEADER_RD (CHAMFERB, 40);


### PR DESCRIPTION
$BLIPMODE is present in DXF in <R14 every time