### PR TITLE
Fix VPORT.UCSICON in DXF output and input

### DIFF
--- a/include/dwg.h
+++ b/include/dwg.h
@@ -2712,7 +2712,7 @@ typedef struct _dwg_object_VPORT
   BITCODE_B UCSFOLLOW;
   BITCODE_BS circle_zoom; /* circle sides: nr of tesselations */
   BITCODE_B FASTZOOM;
-  BITCODE_RC UCSICON;     /* DXF 71:  0: icon_on, 1: icon_at_ucsorg */
+  BITCODE_RC UCSICON;     /* DXF 74:  0: icon_on, 1: icon_at_ucsorg */
   BITCODE_B GRIDMODE;     /* DXF 76: on or off */
   BITCODE_2RD GRIDUNIT;
   BITCODE_B SNAPMODE;     /* DXF 75: on or off */

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -4371,7 +4371,14 @@ DWG_TABLE (VPORT)
     //VIEWMODE: UCSVP bit 0, ucs_at_origin bit 1, UCSFOLLOW bit 3
     FIELD_RS (circle_zoom, 72); // 1000
     FIELD_RS (FASTZOOM, 73);
-    FIELD_RS (UCSICON, 74);
+    { // 1 and 2 are swapped in DXF output, 0 and 3 are on place
+      BITCODE_RC ucsicon = FIELD_VALUE (UCSICON);
+      if (ucsicon == 1)
+        ucsicon = 2;
+      else if (ucsicon == 2)
+        ucsicon = 1;
+      VALUE_RS (ucsicon, 74);
+    }
     FIELD_RS (SNAPMODE, 75);
     FIELD_RS (GRIDMODE, 76);
     FIELD_RS (SNAPSTYLE, 77);

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -10360,6 +10360,18 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
                 return pair;
               goto next_pair;
             }
+          else if (pair->code == 74 && obj->fixedtype == DWG_TYPE_VPORT)
+            {
+              Dwg_Object_VPORT *o = obj->tio.object->tio.VPORT;
+              BITCODE_RC ucsicon = pair->value.i;
+              if (ucsicon == 1) // 1 and 2 are swapped in DXF
+                ucsicon = 2;
+              else if (ucsicon == 2)
+                ucsicon = 1;
+              o->UCSICON = ucsicon;
+              LOG_TRACE ("VPORT.UCSICON = %d [BB 74]\n", o->UCSICON)
+              goto next_pair;
+            }
           else if (pair->code == 65 && obj->fixedtype == DWG_TYPE_VPORT)
             {
               Dwg_Object_VPORT *o = obj->tio.object->tio.VPORT;


### PR DESCRIPTION
The values 1 and 2 of UCSICON are swapped between DWG and DXF representation. There are another values 0 and 3 which are valid.