### PR TITLE
Remove error in check by bit_read_H()

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -6169,7 +6169,7 @@ DWG_OBJECT (PROXY_OBJECT)
 
   START_OBJECT_HANDLE_STREAM;
 #if defined(IS_DECODER)
-  while (hdl_dat->byte < hdl_dat->size)
+  while (hdl_dat->byte < hdl_dat->size - 1)
     {
       Dwg_Handle hdl;
       if (bit_read_H (hdl_dat, &hdl))


### PR DESCRIPTION
-1 means one byte for first bit_read_RC() in bit_read_H().

Before patch:
```
--common_size: 718
proxy_id: 515 [BL 90]
dwg_versions: 0x19 [BLx 95]
> maint_version: 0
> dwg_version: 19
from_dxf: 0 [B 70]
> data_numbits: 2325 [ 93]
9094D65747269633530004B34000000600000000000000002881000000180000000000000000A202229258409E5840A25840A65840B05840B4000000000000001220233000000180009940000006000000000000000028800000000000000A2 objids[0] = (5.1.F) abs:15 [H]
[add handleref (5.0.0) abs:0] objids[1] = (5.0.0) abs:0 [H]
[add handleref (5.1.14) abs:20] objids[2] = (5.1.14) abs:20 [H]
[add handleref (5.1.F) abs:15] objids[3] = (5.1.F) abs:15 [H]
ERROR: bit_read_RC buffer overflow at 403.2 + 1 > 404 num_objids: 4
 padding: +6
 object_map{5C77} = 117
 padding: FF/3F (6 bits)
crc: 2EFA [RSx]
 check_CRC 993626-994032 = 406: 2EFA == 2EFA
```

After patch:
```
--common_size: 718
proxy_id: 515 [BL 90]
dwg_versions: 0x19 [BLx 95]
> maint_version: 0
> dwg_version: 19
from_dxf: 0 [B 70]
> data_numbits: 2325 [ 93]
9094D65747269633530004B34000000600000000000000002881000000180000000000000000A202229258409E5840A25840A65840B05840B4000000000000001220233000000180009940000006000000000000000028800000000000000A2 objids[0] = (5.1.F) abs:15 [H]
[add handleref (5.0.0) abs:0] objids[1] = (5.0.0) abs:0 [H]
[add handleref (5.1.14) abs:20] objids[2] = (5.1.14) abs:20 [H]
[add handleref (5.1.F) abs:15] objids[3] = (5.1.F) abs:15 [H]
num_objids: 4
 padding: +6
 object_map{5C77} = 117
 padding: FF/3F (6 bits)
crc: 2EFA [RSx]
 check_CRC 993626-994032 = 406: 2EFA == 2EFA
``