### PR TITLE
Change LibreDWG.texi (doc)

### DIFF
--- a/doc/LibreDWG.texi
+++ b/doc/LibreDWG.texi
@@ -955,6 +955,8 @@ or 2. by using the API functions from @file{dwg_api.h}:
   for (i=0; i < block_control->num_entries; i++)
     {
       process_BLOCK_HEADER(block_control->block_headers[i]);
+      // replace process_BLOCK_HEADER()'s attribute for the upper line, because block_headers[] does not extend block_control
+      process_BLOCK_HEADER(block_control->entries[i]);          // proposal, instead of the block_headers[i]
     }
   process_BLOCK_HEADER(dwg_paper_space_ref(dwg));
 @end verbatim

--- a/doc/LibreDWG.texi
+++ b/doc/LibreDWG.texi
@@ -941,7 +941,7 @@ via two ways:
   // then all entities in the blocks
   for (i=0; i < block_control->num_entries; i++)
     {
-      process_BLOCK_HEADER(block_control->block_headers[i]);
+      process_BLOCK_HEADER(block_control->entries[i]);
     }
   // and last all entities in the paper space
   process_BLOCK_HEADER(dwg->header_vars.BLOCK_RECORD_PSPACE);
@@ -954,9 +954,7 @@ or 2. by using the API functions from @file{dwg_api.h}:
   process_BLOCK_HEADER(dwg_model_space_ref(dwg));
   for (i=0; i < block_control->num_entries; i++)
     {
-      process_BLOCK_HEADER(block_control->block_headers[i]);
-      // replace process_BLOCK_HEADER()'s attribute for the upper line, because block_headers[] does not extend block_control
-      process_BLOCK_HEADER(block_control->entries[i]);          // proposal, instead of the block_headers[i]
+      process_BLOCK_HEADER(block_control->entries[i]);
     }
   process_BLOCK_HEADER(dwg_paper_space_ref(dwg));
 @end verbatim


### PR DESCRIPTION
change block_headers[]
reason: _not extending_ block_control

In the 7.1 Decoding section (p. 271) is written to pass as attribute block_control->block_headers[i] to the function process_BLOCK_HEADERS() .

block_headers does not extend block_control, which is of data type Dwg_Object_BLOCK_CONTROL* .

**Notable mention**
Everything is followed and implemented right as LibreDWG's official documentation implies.

