### PR TITLE
Fix not obtaining the next owned entity when the ordering changed

### DIFF
--- a/src/dwg.c
+++ b/src/dwg.c
@@ -1264,7 +1264,7 @@ get_next_owned_entity (const Dwg_Object *restrict hdr,
     {
       Dwg_Object *obj;
       if (_hdr->last_entity == NULL
-          || current->handle.value >= _hdr->last_entity->absolute_ref)
+          || current >= _hdr->last_entity->obj)
         return NULL;
       obj = dwg_next_entity (current);
       while (obj


### PR DESCRIPTION
Based on #1114