### PR TITLE
Fix various typos

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -59,7 +59,7 @@ someone should probably think about and resolve them!
 
   The optional number after those 4 numbers is the number of commits not yet
   merged to master. E.g. the 1 in 0.5.0.1093.1_967f.
-  And finally for local development builds the abbrevated git tag, e.g. the 967f
+  And finally for local development builds the abbreviated git tag, e.g. the 967f
   in 0.5.0.1093.1_967f.
 
   So a released version will be 2 or 3 numbers, a development version will also
@@ -177,7 +177,7 @@ someone should probably think about and resolve them!
     see NEWS'
   - merge it into master (ff)
   - update the tag: git tag -d 0.6.2; git tag -s -m 'release 0.6.2' 0.6.2
-  - make dist to create the source tarballs. if seperate build dirs, in a
+  - make dist to create the source tarballs. if separate build dirs, in a
     config with --enable-release only.
   - check if the source tarballs compile
   - push master and tags to run the CI and create the windows binaries on appveyor

--- a/doc/LibreDWG.texi
+++ b/doc/LibreDWG.texi
@@ -1145,7 +1145,7 @@ or converted utf8 string.
 @deftypefn {Function} bool dwg_dynapi_entity_value (void *@var{entity}, const char *@var{dxfname}, const char *@var{fieldname}, void *@var{out}, Dwg_DYNAPI_field *@var{fp})
 @var{entity} is of type @code{dwg_ent_generic}, that is the pointer to the object specific struct.
 @var{dxfname} is the dxfname of the object, @var{fieldname} is the field or property name of the field to be read from,
-*@var{out} the result pointer and the optiona *@var{fp} is filled by the information for this field.
+*@var{out} the result pointer and the optional *@var{fp} is filled by the information for this field.
 @end deftypefn
 
 @deftypefn {Function} bool dwg_dynapi_common_value (void *@var{entity}, const char *@var{fieldname}, void *@var{out}, Dwg_DYNAPI_field *@var{fp})

--- a/include/dwg.h
+++ b/include/dwg.h
@@ -3526,7 +3526,7 @@ typedef struct _dwg_object_VPORT
   BITCODE_2RD lower_left;
   BITCODE_2RD upper_right;
   BITCODE_B UCSFOLLOW;
-  BITCODE_BS circle_zoom; /* circle sides: nr of tesselations */
+  BITCODE_BS circle_zoom; /* circle sides: nr of tessellations */
   BITCODE_B FASTZOOM;
   BITCODE_RC UCSICON;     /* DXF 74:  0: icon_on, 1: icon_at_ucsorg */
   BITCODE_B GRIDMODE;     /* DXF 76: on or off */
@@ -4389,7 +4389,7 @@ typedef struct _dwg_object_PLOTSETTINGS
   BITCODE_BS shadeplot_type; /*!< DXF 76, 0 display, 1 wireframe, 2 hidden, 3
                                 rendered, 4 visualstyle, 5 renderPreset */
   BITCODE_BS
-      shadeplot_reslevel;         /*!< DXF 77, 0 draft, 1 preview, 2 nomal,
+      shadeplot_reslevel;         /*!< DXF 77, 0 draft, 1 preview, 2 normal,
                                                3 presentation, 4 maximum, 5 custom */
   BITCODE_BS shadeplot_customdpi; /*!< DXF 78, 100-32767 */
   BITCODE_H shadeplot;            /*!< DXF 333 optional. As in VIEWPORT */
@@ -11588,7 +11588,7 @@ dwg_get_entity_layer (const Dwg_Object_Entity *restrict);
 
 EXPORT Dwg_Object *dwg_next_object (const Dwg_Object *obj);
 EXPORT Dwg_Object *dwg_next_entity (const Dwg_Object *obj);
-// next available 0 ref + 1, when all refs are alreay filled
+// next available 0 ref + 1, when all refs are already filled
 EXPORT BITCODE_HV dwg_next_handle (const Dwg_Data *dwg);
 // next available handle, computed form the HANDSEED, which is bumped
 EXPORT BITCODE_HV dwg_next_handseed (Dwg_Data *dwg);

--- a/src/common.c
+++ b/src/common.c
@@ -506,7 +506,7 @@ delete_hv (BITCODE_H *entries, BITCODE_BS *num_p, BITCODE_BS i)
     }
 }
 
-// find if handle already exists, returs index or -1
+// find if handle already exists, returns index or -1
 BITCODE_BSd find_hv (BITCODE_H *entries, BITCODE_BS num_entries,
                     BITCODE_RLL handle_value)
 {

--- a/src/decode.c
+++ b/src/decode.c
@@ -6715,7 +6715,7 @@ decode_preR13_entities (BITCODE_RL start, BITCODE_RL end,
     real_start -= 16;
   }
 
-  // report unknown data before entites block
+  // report unknown data before entities block
   if (start != end && real_start > 0 && (BITCODE_RL)dat->byte != real_start)
     {
       LOG_WARN ("\n@0x%zx => start 0x%x", dat->byte, real_start);

--- a/src/dwg.c
+++ b/src/dwg.c
@@ -2889,8 +2889,8 @@ dwg_handle_name (Dwg_Data *restrict dwg, const char *restrict table,
       _o = hobj->tio.object->tio.APPID;
       name = hobj->name;
       /* For BLOCK search the BLOCK entities instead.
-         The BLOCK_HEADER has only the abbrevated name, but we want "*D30", not
-         "*D" */
+         The BLOCK_HEADER has only the abbreviated name, but we want "*D30",
+         not "*D" */
       if (strEQc (table, "BLOCK") && hobj->fixedtype == DWG_TYPE_BLOCK_HEADER)
         {
           Dwg_Object_BLOCK_HEADER *_bh = hobj->tio.object->tio.BLOCK_HEADER;

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -11850,7 +11850,7 @@ DWG_ENTITY (JUMP)
       }
 
 #ifdef IS_DECODER
-    /* rest: TODO seperate unknown_bits from unknown_rest */
+    /* rest: TODO separate unknown_bits from unknown_rest */
     if (dat->byte < obj->address + obj->size)
       {
         len = obj->address + obj->size - dat->byte;

--- a/src/header.spec
+++ b/src/header.spec
@@ -38,7 +38,7 @@
     FIELD_RS (numheader_vars, 0); // 74,83,101,104,114,120,122,129,158,160,204,205
     FIELD_RC (dwg_version, 0); // 0
 
-    // The 3 entitity data sections
+    // The 3 entity data sections
     FIELD_RLx (entities_start, 0);
     FIELD_RLx (entities_end, 0);
     FIELD_RLx (blocks_start, 0);

--- a/test/unit-testing/bits_test.c
+++ b/test/unit-testing/bits_test.c
@@ -464,7 +464,7 @@ bit_BL_tests (void)
   bitfree (&bitchain);
 }
 
-// seperate branches for bit=0 and bit=1
+// separate branches for bit=0 and bit=1
 static void
 bit_RD_tests (void)
 {
@@ -502,7 +502,7 @@ bit_RD_tests (void)
   bitfree (&bitchain);
 }
 
-// seperate branches for bit=0 and bit=1
+// separate branches for bit=0 and bit=1
 static void
 bit_BD_tests (void)
 {

--- a/test/unit-testing/vport.c
+++ b/test/unit-testing/vport.c
@@ -37,7 +37,7 @@ api_process (dwg_object *obj)
   BITCODE_2RD lower_left;
   BITCODE_2RD upper_right;
   BITCODE_B UCSFOLLOW;
-  BITCODE_BS circle_zoom; /* circle sides: nr of tesselations */
+  BITCODE_BS circle_zoom; /* circle sides: nr of tessellations */
   BITCODE_B FASTZOOM;
   BITCODE_RC UCSICON;
   BITCODE_B GRIDMODE;
@@ -98,7 +98,7 @@ api_process (dwg_object *obj)
   CHK_ENTITY_2RD (_obj, VPORT, upper_right);
   CHK_ENTITY_TYPE (_obj, VPORT, UCSFOLLOW, B);
   CHK_ENTITY_TYPE (_obj, VPORT, circle_zoom,
-                   BS); /* circle sides: nr of tesselations */
+                   BS); /* circle sides: nr of tessellations */
   CHK_ENTITY_TYPE (_obj, VPORT, FASTZOOM, B);
   CHK_ENTITY_TYPE (_obj, VPORT, UCSICON, RC);
   CHK_ENTITY_TYPE (_obj, VPORT, GRIDMODE, B);


### PR DESCRIPTION
Found via: `codespell -q 3 -S "./.git,*.patch,ChangeLog,./NEWS,./src/codepages" -L 2rd,aadd,addd,aded,afe,ba,baed,beed,caf,childs,daa,ded,ede,fo,gir,gord,gost,nam,noo,oce,re-use,ro,siz,te,teh,tekst,ue,uptodate`