### PR TITLE
1216 - fix: Layer Color Index now matches the RGB value

### DIFF
--- a/src/out_json.c
+++ b/src/out_json.c
@@ -612,12 +612,35 @@ field_cmc (Bit_Chain *dat, const char *restrict key,
     {
       KEYs (_path_field (key));
       HASH;
-      if (_obj->index)
+      if (_obj->index && _obj->index != 256) 
+        {
+          FIELD_BS(index, 62);
+        }
+      else if (_obj->method == 0xc2 || _obj->method == 0xc3 || _obj->method == 0) 
+        {
+          BITCODE_BS index;
+          if (_obj->method == 0xc3)
+            {
+              index = (BITCODE_BS)(_obj->rgb & 0xFF);
+            }
+          else
+            {
+              index = dwg_find_color_index (_obj->rgb & 0xFFFFFF);
+            }
+          if (index > 0 && index < 256) 
+            {
+              FIRSTPREFIX fprintf (dat->fh, "\"index\":%s%d", JSON_SPC, index);
+            } 
+          else if (_obj->index == 256) 
+            {
+              FIELD_BS (index, 62);
+            }
+        }
+      else if (_obj->index)
         {
           FIELD_BS (index, 62);
         }
-      FIRSTPREFIX fprintf (dat->fh, "\"rgb\":%s\"%06x\"", JSON_SPC,
-                           (unsigned)_obj->rgb);
+      FIRSTPREFIX fprintf (dat->fh, "\"rgb\":%s\"%08x\"", JSON_SPC, (unsigned)_obj->rgb);
       if (_obj->flag)
         {
           FIELD_BS (flag, 0);


### PR DESCRIPTION
This is the fix for ticket [1216](https://github.com/LibreDWG/libredwg/issues/1216)

Technical Analysis: The RGB value is 0xc3000073.
- High Byte (0xc3): Indicates the color method is ByACI (AutoCAD Color Index).
- Low Byte (0x73): Hex 73 equals Decimal 115. It appears the parser is not extracting the low byte when the 0xc3 flag is present in the nested color object.