### PR TITLE
Fix compilation issues on modern systems with GCC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,9 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 dnl create a config.h file (Automake will add -DHAVE_CONFIG_H)
 AC_CONFIG_HEADERS([src/config.h])
+AH_TOP([#ifndef CONFIG_H
+#define CONFIG_H 1])
+AH_BOTTOM([#endif /* CONFIG_H */])
 AC_MSG_CHECKING([PACKAGE_VERSION])
 AC_MSG_RESULT($PACKAGE_VERSION)
 AC_MSG_CHECKING([LIBREDWG_SO_VERSION])
@@ -222,7 +225,11 @@ darwin*|macos*)
     AC_DEFINE([_POSIX_C_SOURCE],[900000L],[Needed for all APPLE extensions])
     ;;
 *)
-    AC_DEFINE([_POSIX_C_SOURCE],[200809L],[Needed for strdup])
+    AH_VERBATIM([_POSIX_C_SOURCE],
+[/* Needed for strdup */
+#ifndef _POSIX_C_SOURCE
+# define _POSIX_C_SOURCE 200809L
+#endif])
     ;;
 esac
 case "$host_os" in

--- a/src/bits.c
+++ b/src/bits.c
@@ -3180,8 +3180,11 @@ static char *
 bit_is_U_expand (const char *p)
 {
   char *s;
-  if (p && strlen (p) >= 7 && (s = strstr (p, "\\U+")) && ishex (s[3])
-      && ishex (s[4]) && ishex (s[5]) && ishex (s[6]))
+  if (!p || strlen (p) < 7)
+    return NULL;
+  
+  s = (char *)strstr (p, "\\U+");
+  if (s && ishex (s[3]) && ishex (s[4]) && ishex (s[5]) && ishex (s[6]))
     return s;
   else
     return NULL;
@@ -3191,9 +3194,12 @@ static char *
 bit_is_M_expand (const char *p)
 {
   char *s;
-  if (p && strlen (p) >= 8 && (s = strstr (p, "\\M+")) && s[3] >= '1'
-      && s[3] <= '5' && ishex (s[4]) && ishex (s[5]) && ishex (s[6])
-      && ishex (s[7]))
+  if (!p || strlen (p) < 8)
+    return NULL;
+  
+  s = (char *)strstr (p, "\\M+");
+  if (s && s[3] >= '1' && s[3] <= '5' && ishex (s[4]) && ishex (s[5])
+      && ishex (s[6]) && ishex (s[7]))
     return s;
   else
     return NULL;


### PR DESCRIPTION
In systems with modern glibc (like Arch Linux), including system
headers before config.h could lead to _POSIX_C_SOURCE macro
redefinition errors. Added include guards to config.h and a #ifndef
protection for _POSIX_C_SOURCE to prevent this.
Also, fixed a -Werror=discarded-qualifiers warning when casting
the result of strstr to char * in bits.c.

* configure.ac: Add AH_TOP and AH_BOTTOM for CONFIG_H include guards.
  Use AH_VERBATIM to wrap _POSIX_C_SOURCE in #ifndef.
* src/bits.c (bit_is_U_expand, bit_is_M_expand): Add explicit (char *)
  cast to the strstr return value.
* src/config.h.in: Regenerated to reflect the new include guards and
  macro protections.
