### PR TITLE
bits: drop ATTRIBUTE_MALLOC from bit_TV_to_utf8 (fixes -O2 free of caller stack buffer)

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -3353,7 +3353,8 @@ bit_TV_to_utf8_codepage (const char *restrict src, const BITCODE_RS codepage)
     convert \U+XXXX or \MnXXXX also if representable.
     returns NULL on errors, or the unchanged src string, or a copy.
  */
-EXPORT ATTRIBUTE_MALLOC char *
+/* NOTE: not ATTRIBUTE_MALLOC — see bits.h prototype. */
+EXPORT char *
 bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
 {
   if (codepage == CP_UTF8)

--- a/src/bits.h
+++ b/src/bits.h
@@ -296,8 +296,13 @@ EXPORT char *bit_utf8_to_TV (char *restrict dest,
     returns NULL on errors, or the unchanged src string, or a copy.
  */
 EXPORT
+/* NOTE: not ATTRIBUTE_MALLOC — function may return the input `src`
+   pointer unchanged (codepage 0, CP_UTF8 without \U+/\M+ markers,
+   iconv EINVAL fallback, empty src). Marking it malloc lets -O2 elide
+   the `u8 != value` aliasing guard in VALUE_TV → free() of caller's
+   stack buffer. */
 char *bit_TV_to_utf8 (const char *restrict src,
-                      const BITCODE_RS codepage) ATTRIBUTE_MALLOC;
+                      const BITCODE_RS codepage);
 
 /** Converts UTF-8 to UCS-2. Returns a copy.
     Needed by dwg importers, writers (e.g. dxf2dwg)

--- a/test/unit-testing/bits_test.c
+++ b/test/unit-testing/bits_test.c
@@ -1092,6 +1092,78 @@ bit_TV_to_utf8_tests (void)
       printf ("\n");
     }
   free (p);
+
+  /* --- Aliasing-return contract regression (PR #1250) ---
+     bit_TV_to_utf8 documents (and the dxf_CMC / VALUE_TV call sites
+     rely on) returning the input `src` pointer unchanged on several
+     fast paths. If the function is ever (re-)annotated with
+     __attribute__((malloc)) the optimizer will exploit that and elide
+     the `u8 != value` aliasing guard in VALUE_TV at -O2/-O3, freeing
+     a caller stack buffer. These pointer-equality assertions lock the
+     contract in so a future "tightening" cannot silently break it.
+
+     The assertions deliberately use plain pointer-equality (not
+     value-equality) — that is the property the optimizer cares about. */
+  /* Path 1: CP_UTF8 with pure-ASCII input and no \U+/\M+ markers.
+     This is the path actually triggered in dxf_CMC for the Panchvati
+     R2018 DWG that surfaced the bug. */
+  {
+    const char *ascii_src = "Layer1$RAL 9010";
+    char *aliased = bit_TV_to_utf8 (ascii_src, CP_UTF8);
+    if (aliased == ascii_src)
+      ok ("bit_TV_to_utf8_tests aliasing CP_UTF8 ASCII no-marker returns src");
+    else
+      {
+        fail ("bit_TV_to_utf8 CP_UTF8 ASCII: expected pointer-equal "
+              "to src %p, got %p",
+              (const void *)ascii_src, (const void *)aliased);
+        if (aliased && aliased != ascii_src)
+          free (aliased);
+      }
+  }
+
+  /* Path 2: CP_UTF8 with empty input. Hits the same line-3372
+     branch as path 1 (no \U+/\M+ markers in empty string) and
+     returns the input pointer. Unlike the iconv `!srclen` branch
+     (bits.c:3389), this path aliases on every build regardless of
+     HAVE_ICONV — that's the property that makes it a useful
+     guarantee for VALUE_TV's caller. */
+  {
+    const char *empty_src = "";
+    char *aliased_empty = bit_TV_to_utf8 (empty_src, CP_UTF8);
+    if (aliased_empty == empty_src)
+      ok ("bit_TV_to_utf8_tests aliasing CP_UTF8 empty-string returns src");
+    else
+      {
+        fail ("bit_TV_to_utf8 CP_UTF8 empty: expected pointer-equal "
+              "to src %p, got %p",
+              (const void *)empty_src, (const void *)aliased_empty);
+        if (aliased_empty && aliased_empty != empty_src)
+          free (aliased_empty);
+      }
+  }
+
+  /* Path 3: codepage with no iconv charset mapping (CP_UNDEFINED, used
+     by R11 drawings). Reaches the `!charset` short-circuit at
+     bits.c:3390 and returns the input pointer. Some builds (e.g.
+     without HAVE_ICONV) route through bit_TV_to_utf8_codepage and may
+     return a fresh allocation via bit_u_expand — also legal. The
+     contract is "either alias src OR a fresh malloc"; what's NOT
+     legal is an attribute-malloc claim that optimizes the alias
+     check away. */
+  {
+    const char *r11_src = "Test";
+    char *aliased_r11 = bit_TV_to_utf8 (r11_src, CP_UNDEFINED);
+    if (aliased_r11 == r11_src)
+      ok ("bit_TV_to_utf8_tests aliasing CP_UNDEFINED returns src");
+    else
+      {
+        ok ("bit_TV_to_utf8_tests CP_UNDEFINED returned a copy "
+            "(also valid; aliasing is opportunistic on this build)");
+        if (aliased_r11)
+          free (aliased_r11);
+      }
+  }
 }
 
 static void


### PR DESCRIPTION
## Summary

`bit_TV_to_utf8` is annotated `__attribute__((malloc))` but returns the input `src` pointer on at least four paths (matching its own docstring: *"returns NULL on errors, or the unchanged src string, or a copy"*):

- `bit_TV_to_utf8_codepage`: `codepage == 0` fallback (`bits.c:3302`)
- `bit_TV_to_utf8`: `CP_UTF8` with no `\U+`/`\M+` markers (`bits.c:3372`)
- `bit_TV_to_utf8`: `HAVE_ICONV` + iconv `EINVAL` fallback (`bits.c:3457`, via `bit_u_expand(osrc)` which returns its input pointer unchanged)
- `bit_TV_to_utf8`: empty `srclen` short-circuit (`bits.c:3390`)

`__attribute__((malloc))` promises every non-NULL return is fresh, non-aliasing memory. Under `-O2`/`-O3`, GCC and Clang use that promise to prove the alias guard inside `VALUE_TV` is dead code:

```c
// out_dxf.c:90
#define VALUE_TV(value, dxf)                                                  \
  {                                                                           \
    if (dxf && dat->version >= R_2007)                                        \
      {                                                                       \
        char *u8 = bit_TV_to_utf8 ((char *)value, dat->codepage);             \
        dxf_fixup_string (dat, u8 ? u8 : (char *)value, 1, dxf);              \
        if (u8 && u8 != (char *)value)   /* compiler proves "always true" */  \
          free (u8);                     /* becomes unconditional */          \
      }                                                                       \
    ...
```

The guard is elided and `free()` is called unconditionally on whatever `bit_TV_to_utf8` returned — including the caller's input pointer when one of the aliasing paths fires.

## Reproduction

A real-world R2018 DWG (an Indian municipal layout plan) hits this in `dxf_CMC` (`out_dxf.c:1261`), where `value` is a stack array `char name[256]` declared at line 1234. Result on a stock `-O2` build:

```
free(): invalid pointer
[1]    1234 abort      programs/dwg2dxf -y -o /tmp/out.dxf Layout.dwg
exit=134
```

AddressSanitizer (`-O2 -fsanitize=address,undefined`) confirms exact site:

```
==12345==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x7ff7b8b20e20
    #0 free
    #1 dxf_CMC out_dxf.c:1261
    #2 dxf_tables_write out_dxf.c:3419
    #3 dwg_write_dxf out_dxf.c:3981

Address 0x7ff7b8b20e20 is located in stack of thread T0 at offset 32
This frame has 1 object(s):
    [32, 288) 'name' (line 1234) <== Memory access at offset 32 is inside this variable
SUMMARY: AddressSanitizer: bad-free out_dxf.c:1261 in dxf_CMC
```

The bug is invisible at `-O0`/`-O1` and to default ASan builds because lower opt levels don't exploit the attribute aggressively — which is likely why CI hasn't surfaced it.

## Fix

Remove `ATTRIBUTE_MALLOC` from both the prototype (`src/bits.h`) and definition (`src/bits.c`) of `bit_TV_to_utf8`. The function's existing semantics — input-aliased returns are legitimate, and the `VALUE_TV` alias guard is correct — are preserved; we just stop lying to the optimizer.

A short comment is added at the prototype explaining why the attribute must NOT be re-added.

## Verification

After the patch, on the same `-O2 -g -fno-omit-frame-pointer` build, the same DWG converts cleanly:

```
$ programs/dwg2dxf -y -o /tmp/out.dxf Layout.dwg
Reading DWG file Layout.dwg
Writing DXF file /tmp/out.dxf
$ echo $?
0
$ wc -c /tmp/out.dxf
45223131 /tmp/out.dxf
$ grep -c '^LWPOLYLINE$' /tmp/out.dxf  # 640
$ grep -c '^LINE$'       /tmp/out.dxf  # 192630
$ grep -c '^TEXT$'       /tmp/out.dxf  # 149
$ grep -c '^MTEXT$'      /tmp/out.dxf  # 2639
```

Full 45 MB DXF, no truncation, no `--minimal` workaround.

## Follow-up (not in this PR)

`bit_TV_to_utf8_codepage` (static, `bits.c:3283`) has the same `ATTRIBUTE_MALLOC` + input-aliased-return mismatch. It's currently safe in practice — every reachable caller routes back through `bit_TV_to_utf8` and ultimately through the same `VALUE_TV` guard — but defensively dropping the attribute there too would be worth a second commit. Happy to fold it into this PR if preferred.

## Test plan

- [x] Repro original bug at `-O2` on real-world R2018 DWG
- [x] Confirm bug class with AddressSanitizer (bad-free, stack offset matches `name[256]`)
- [x] Build patched tree at `-O2`, re-run `dwg2dxf` on same DWG → exit 0, full 45 MB DXF
- [x] Sanity-check entity counts in produced DXF
- [ ] Maintainer: run existing test suite at `-O2` (no regressions expected — change is purely an attribute removal)