### PR TITLE
fix 2 reported cases

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -3514,7 +3514,8 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
         if (errno != 22)
           LOG_WARN ("iconv_open (\"%s\", \"%s\") failed with errno %d",
                     utf8_cs, charset, errno);
-        free (odest);
+        if (odest)
+          free (odest);
         return bit_TV_to_utf8_codepage (src, codepage);
       }
     while (nconv == (size_t)-1)
@@ -3540,7 +3541,8 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
                                " for %s",
                                odestlen, src);
                     iconv_close (cd);
-                    free (odest);
+                    if (odest)
+                      free (odest);
                     return NULL;
                   }
                 dest_new = (char *)realloc (odest, odestlen + 1);
@@ -3555,7 +3557,8 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
                     loglevel |= 1;
                     LOG_ERROR ("Out of memory");
                     iconv_close (cd);
-                    // free (odest);
+                    if (odest)
+                      free (odest);
                     return NULL;
                   }
               }
@@ -3564,7 +3567,8 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
                 loglevel |= 1;
                 LOG_ERROR ("iconv \"%s\" failed with errno %d", src, errno);
                 iconv_close (cd);
-                free (odest);
+                if (odest)
+                  free (odest);
                 return (char *)bit_u_expand (osrc);
               }
           }
@@ -3584,7 +3588,8 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
     else
       {
         iconv_close (cd);
-        free (odest);
+        if (odest)
+          free (odest);
         return bit_TV_to_utf8_codepage (osrc, codepage);
       }
 #else

--- a/src/bits.c
+++ b/src/bits.c
@@ -3467,7 +3467,13 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
           // NOTE: src is expanded/shrinked internally.
           const size_t srclen = strlen (src);
           size_t destlen = 1 + trunc (srclen * 2);
-          char *dest = (char *)calloc (destlen, 1);
+          char *dest = (char *)calloc (destlen + 1, 1);
+          if (!dest)
+            {
+              loglevel |= 1;
+              LOG_ERROR ("Out of memory");
+              return NULL;
+            }
           memcpy (dest, src, srclen + 1);
           return (char *)bit_u_expand (dest);
         }
@@ -3493,7 +3499,7 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
     if (!charset || !srclen)
       return (char *)src;
     osrc = (char *)src;
-    odest = dest = (char *)calloc (odestlen, 1);
+    odest = dest = (char *)calloc (odestlen + 1, 1);
     if (!odest || destlen > 0x2FFFE)
       {
         loglevel |= 1;
@@ -3522,26 +3528,27 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
 #  endif
         if (nconv == (size_t)-1)
           {
-            if (errno != EINVAL) // probably dest buffer too small
+            if (errno == E2BIG) // dest buffer too small
               {
                 char *dest_new;
-                destlen *= 2;
-                if (destlen > 0x2FFFE)
+                size_t offset = (size_t)(dest - odest);
+                odestlen *= 2;
+                if (odestlen > 0x2FFFE)
                   {
                     loglevel |= 1;
                     LOG_ERROR ("bit_TV_to_utf8: overlarge destlen %" PRIuSIZE
                                " for %s",
-                               destlen, src);
+                               odestlen, src);
                     iconv_close (cd);
                     free (odest);
                     return NULL;
                   }
-                dest_new = (char *)realloc (odest, destlen);
+                dest_new = (char *)realloc (odest, odestlen + 1);
                 if (dest_new)
                   {
-                    odest = dest = dest_new;
-                    odestlen = destlen;
-                    dest_new[destlen - 1] = '\0';
+                    odest = dest_new;
+                    dest = dest_new + offset;
+                    destlen = odestlen - offset;
                   }
                 else
                   {
@@ -3567,7 +3574,7 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
     if (errno == 0 && destlen <= 0x2FFFE && (uintptr_t)dest >= (uintptr_t)odest
         && (uintptr_t)dest <= (uintptr_t)odest + odestlen)
       {
-        //*dest = '\0';
+        *dest = '\0';
         iconv_close (cd);
         // always gets shorter, so inplace
         return (char *)bit_u_expand (odest);

--- a/src/bits.c
+++ b/src/bits.c
@@ -3570,8 +3570,10 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
           }
       }
     // flush the remains
-    iconv (cd, NULL, NULL, (char **)&dest, (size_t *)&destlen);
-    if (errno == 0 && destlen <= 0x2FFFE && (uintptr_t)dest >= (uintptr_t)odest
+    errno = 0;
+    nconv = iconv (cd, NULL, NULL, (char **)&dest, (size_t *)&destlen);
+    if (nconv != (size_t)-1 && destlen <= 0x2FFFE
+        && (uintptr_t)dest >= (uintptr_t)odest
         && (uintptr_t)dest <= (uintptr_t)odest + odestlen)
       {
         *dest = '\0';
@@ -3583,7 +3585,7 @@ bit_TV_to_utf8 (const char *restrict src, const BITCODE_RS codepage)
       {
         iconv_close (cd);
         free (odest);
-        return bit_TV_to_utf8_codepage (src, codepage);
+        return bit_TV_to_utf8_codepage (osrc, codepage);
       }
 #else
     return bit_TV_to_utf8_codepage (src, codepage);

--- a/src/enc_macros.h
+++ b/src/enc_macros.h
@@ -869,6 +869,7 @@
       { /* save away special accumulated hdls, need to write common first */  \
         Bit_Chain dat1 = *hdl_dat;                                            \
         Bit_Chain dat2 = { 0 };                                               \
+        hdl_dat->chain = NULL; /* dat1 owns it now; prevent double-free */    \
         bit_chain_init_dat (&dat2, 12, dat);                                  \
         hdl_dat = &dat2;                                                      \
         ENCODE_COMMON_HANDLES /* owner, xdic, reactors */                     \

--- a/test/unit-testing/bits_test.c
+++ b/test/unit-testing/bits_test.c
@@ -1164,6 +1164,31 @@ bit_TV_to_utf8_tests (void)
           free (aliased_r11);
       }
   }
+  /* --- iconv NUL-termination regression (commit dc8e3509) ---
+     bit_TV_to_utf8 iconv path must always NUL-terminate.  When iconv
+     fills the destination buffer exactly, dest points past the
+     allocation and *dest='\0' would OOB-write without the +1 in the
+     calloc/realloc sizing.  Verify strlen returns sane results on
+     the iconv path for a multi-byte codepage. */
+  {
+    // CP_ANSI_932 (Shift-JIS): multi-byte input triggers iconv
+    const char *sjis_input = "\x83\x82\x83\x6d"; // モノ
+    p = bit_TV_to_utf8 (sjis_input, CP_ANSI_932);
+    if (!p)
+      fail ("bit_TV_to_utf8 iconv NUL-term: returned NULL");
+    else
+      {
+        size_t len = strlen (p);
+        if (len == 0 || len > 32)
+          fail ("bit_TV_to_utf8 iconv NUL-term: strlen=%zu (expected "
+                "3..15)",
+                len);
+        else
+          ok ("bit_TV_to_utf8 iconv NUL-term");
+      }
+    if (p != sjis_input)
+      free (p);
+  }
 }
 
 static void

--- a/test/unit-testing/encode_test.c
+++ b/test/unit-testing/encode_test.c
@@ -273,6 +273,37 @@ cleanup:
   free (dec.chain);
 }
 
+/* Regression test for double-free fix in COMMON_ENTITY_HANDLE_DATA
+   (commit 6deac10e).  The macro copies *hdl_dat to dat1 then NULLs
+   hdl_dat->chain so dat1 owns the buffer exclusively.  Without the
+   NULL, bit_chain_free(hdl_dat) after bit_chain_free(&dat1) would
+   double-free. */
+static void
+common_entity_handle_data_double_free_test (void)
+{
+  Bit_Chain hdl_dat = { 0 };
+  char *buf = (char *)calloc (64, 1);
+  if (!buf)
+    {
+      fail ("common_entity_handle_data: calloc failed");
+      return;
+    }
+  hdl_dat.chain = (unsigned char *)buf;
+  hdl_dat.size = 64;
+  hdl_dat.byte = 0;
+  hdl_dat.bit = 0;
+
+  /* Simulate the macro's copy-then-NULL pattern */
+  {
+    Bit_Chain dat1 = hdl_dat; /* copy: dat1.chain = hdl_dat.chain */
+    hdl_dat.chain = NULL;     /* the fix: transfer ownership */
+    bit_chain_free (&dat1);   /* free the buffer through dat1 */
+  }
+  /* hdl_dat.chain is now NULL — freeing it must be a no-op */
+  bit_chain_free (&hdl_dat);
+  ok ("common_entity_handle_data double-free regression");
+}
+
 int
 main (int argc, char const *argv[])
 {
@@ -287,5 +318,6 @@ main (int argc, char const *argv[])
   test_section_move_before (&dwg);
 
   compress_R2004_section_tests ();
+  common_entity_handle_data_double_free_test ();
   return failed;
 }


### PR DESCRIPTION
- CWE-125 OOB read / CWE-200 heap disclosure in bit_TV_to_utf8
- CVE-2021-36080 double-free COMMON_ENTITY_HANDLE_DATA for 3DSOLID/BODY/REGION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two memory-safety bugs and adds regression tests. Prevents a heap OOB read/disclosure in UTF-8/iconv conversion and a double-free in entity handle encoding; also fixes a realloc leak.

- **Bug Fixes**
  - bit_TV_to_utf8: Always NUL-terminate and allocate +1 on all paths; fix iconv flush check (use nconv != (size_t)-1) and pass osrc to the fallback; on E2BIG double odestlen, preserve the write offset, and recompute destlen; free on realloc failure; add OOM guards to prevent heap OOB read/disclosure (CWE-125/CWE-200).
  - COMMON_ENTITY_HANDLE_DATA: Set hdl_dat->chain = NULL after copying to transfer ownership and prevent double-free in 3DSOLID/BODY/REGION.

<sup>Written for commit 7961730d54dc3a9204a541ae466c6a72b44b98aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LibreDWG/libredwg/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

