### PR TITLE
in_dxf: fix HATCH spline tangent DXF codes and LTYPE strings_area ove…

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -2290,6 +2290,7 @@ add_LTYPE_dashes (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   Dwg_Data *dwg = obj->parent;
   int num_dashes = (int)o->numdashes;
   int is_tu = 0;
+  unsigned dash_i = 0;
 
   o->dashes
       = (Dwg_LTYPE_dash *)xcalloc (o->numdashes, sizeof (Dwg_LTYPE_dash));
@@ -2372,7 +2373,7 @@ add_LTYPE_dashes (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         }
       else if (pair->code == 9)
         {
-          static unsigned dash_i = 0;
+          size_t strings_size, needed;
           is_tu = obj->parent->header.version >= R_2007;
           CHK_dashes (j, dashes);
           o->dashes[j].text
@@ -2380,19 +2381,33 @@ add_LTYPE_dashes (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
           LOG_TRACE ("LTYPE.dashes[%d].text = %s [T 9]\n", j,
                      pair->value.s.ptr);
           // write into strings_area
+          strings_size = is_tu ? 512 : 256;
           if (!o->strings_area)
-            o->strings_area = (BITCODE_TF)xcalloc (is_tu ? 512 : 256, 1);
+            o->strings_area = (BITCODE_TF)xcalloc (strings_size, 1);
           if (is_tu)
             {
+              needed = ((strlen (pair->value.s.ptr) * 2) + 2);
+              if (dash_i + needed > strings_size)
+                {
+                  LOG_WARN ("LTYPE strings_area overflow, truncating");
+                  goto skip_overflow;
+                }
               bit_wcs2cpy ((BITCODE_TU)&o->strings_area[dash_i],
                            (BITCODE_TU)o->dashes[j].text);
-              dash_i += ((strlen (pair->value.s.ptr) * 2) & UINT_MAX) + 2;
+              dash_i += needed;
             }
           else
             {
+              needed = strlen (pair->value.s.ptr) + 1;
+              if (dash_i + needed > strings_size)
+                {
+                  LOG_WARN ("LTYPE strings_area overflow, truncating");
+                  goto skip_overflow;
+                }
               strcpy ((char *)&o->strings_area[dash_i], o->dashes[j].text);
-              dash_i += (strlen (pair->value.s.ptr) & UINT_MAX) + 1;
+              dash_i += needed;
             }
+        skip_overflow:;
         }
       else
         break; // not a Dwg_LTYPE_dash
@@ -3412,6 +3427,60 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
                         j, k, o->paths[j].segs[k].curve_type, pair->code);
             }
         }
+      else if (pair->code == 12 && !is_plpath && !o->num_seeds)
+        {
+          CHK_paths;
+          CHK_segs;
+          if (o->paths[j].segs[k].curve_type == 4)
+            {
+              o->paths[j].segs[k].start_tangent.x = pair->value.d;
+            }
+          else
+            goto unknown_HATCH;
+        }
+      else if (pair->code == 22 && !is_plpath && !o->num_seeds)
+        {
+          CHK_paths;
+          CHK_segs;
+          if (o->paths[j].segs[k].curve_type == 4)
+            {
+              o->paths[j].segs[k].start_tangent.y = pair->value.d;
+              LOG_TRACE ("HATCH.paths[%d].segs[%d].start_tangent = (%f, %f) "
+                         "[2RD 12]\n",
+                         j, k, o->paths[j].segs[k].start_tangent.x,
+                         pair->value.d);
+            }
+          else
+            goto unknown_HATCH;
+        }
+      else if (pair->code == 13 && !is_plpath && !o->num_seeds)
+        {
+          CHK_paths;
+          CHK_segs;
+          if (o->paths[j].segs[k].curve_type == 4)
+            {
+              o->paths[j].segs[k].end_tangent.x = pair->value.d;
+            }
+          else
+            goto unknown_HATCH;
+        }
+      else if (pair->code == 23 && !is_plpath && !o->num_seeds)
+        {
+          CHK_paths;
+          CHK_segs;
+          if (o->paths[j].segs[k].curve_type == 4)
+            {
+              o->paths[j].segs[k].end_tangent.y = pair->value.d;
+              LOG_TRACE ("HATCH.paths[%d].segs[%d].end_tangent = (%f, %f) "
+                         "[2RD 13]\n",
+                         j, k, o->paths[j].segs[k].end_tangent.x,
+                         pair->value.d);
+              // done with this spline segment, next 97 is num_boundary_handles
+              k = -1;
+            }
+          else
+            goto unknown_HATCH;
+        }
       else if (pair->code == 40 && !is_plpath)
         {
           CHK_paths;
@@ -3582,11 +3651,13 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
             {
               next_330_boundary_handles = false;
               o->paths[j].segs[k].num_fitpts = pair->value.l;
+              l = -1; // reset fitpts index
               LOG_TRACE (
                   "HATCH.paths[%d].segs[%d].num_fitpts  = %ld [BL 97]\n", j, k,
                   pair->value.l);
-              o->paths[j].segs[k].fitpts = (BITCODE_2RD *)xcalloc (
-                  pair->value.l, sizeof (BITCODE_2RD));
+              if (pair->value.l > 0)
+                o->paths[j].segs[k].fitpts = (BITCODE_2RD *)xcalloc (
+                    pair->value.l, sizeof (BITCODE_2RD));
             }
         }
       else if (pair->code == 97 && is_plpath)


### PR DESCRIPTION
* add_HATCH: handle DXF codes 12/22 (start_tangent) and 13/23 (end_tangent)
  for spline boundary paths (curve_type 4).  After end_tangent, set k=-1
  so the next code 97 is handled as num_boundary_handles.

* add_HATCH: move CHK_segs in code 97 handler into the num_fitpts branch
  only, fixing a false error when k=-1 from the end_tangent handler.

* add_LTYPE_dashes: fix heap buffer overflow via group-code-9 strings
  (CWE-122).  Remove static dash_i counter (Variant B: persisted across
  LTYPE calls) and add bounds check before copying into the 256/512-byte
  strings_area buffer (Variant A: up to 4096-byte strings).

GH #1209

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HATCH spline tangent parsing and fit-point allocation, and adds bounds checks for LTYPE code 9 strings to prevent `strings_area` overflow. Improves DXF import correctness and safety.

- **Bug Fixes**
  - HATCH: parse spline start/end tangents (codes 12/22, 13/23) for `curve_type` 4; after end, set `k = -1` so the next 97 is `num_boundary_handles`.
  - HATCH: in code 97, check segs only when reading `num_fitpts`, reset `l = -1`, and allocate `fitpts` only when `num_fitpts > 0` to avoid encoder errors.
  - LTYPE: bound-check code 9 string copies, replace the static dash index with a local counter, and skip writes that would overflow the 256/512-byte `strings_area` buffers.

<sup>Written for commit a59a1a1e968343262492e90e5de1239ae9336ce9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LibreDWG/libredwg/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

