### PR TITLE
encode: force size recalculation for pre-R13 entities after JSON import

### DIFF
--- a/src/encode.c
+++ b/src/encode.c
@@ -5355,23 +5355,30 @@ encode_preR13_entities (EntitySectionIndexR11 section, Bit_Chain *restrict dat,
       else if (!in_blocks && obj->fixedtype == DWG_TYPE_BLOCK)
         in_blocks = true;
 
-      SINCE (R_2_0)
+      SINCE (R_2_0b)
       {
         // patchup size
-        if (!obj->size)
+        // Pre-R13 entity sizes are fixed. Still always recalculate after
+        // JSON import which may have set obj->size from the source.
+        size_t pos = dat->byte;
+        size_t computed_size = dat->byte - obj->address;
+        SINCE (R_11)
+        {
+          computed_size += 2; // crc16
+        }
+        if (computed_size > UINT16_MAX)
           {
-            size_t pos = dat->byte;
-            obj->size = (dat->byte - obj->address) & 0xFFFFFFFF;
-            SINCE (R_11)
-            {
-              obj->size += 2; // crc16
-            }
-            dat->byte = size_pos;
-            bit_write_RS (dat, obj->size);
-            LOG_TRACE ("-size: %u [RL] (@%" PRIuSIZE ".%u)\n", obj->size,
-                       dat->byte, dat->bit);
-            dat->byte = pos;
+            LOG_ERROR ("Entity size %" PRIuSIZE " exceeds RS limit (0xFFFF)",
+                       computed_size);
+            *error |= DWG_ERR_VALUEOUTOFBOUNDS;
+            computed_size = UINT16_MAX;
           }
+        obj->size = (BITCODE_RL)computed_size;
+        dat->byte = size_pos;
+        bit_write_RS (dat, (BITCODE_RS)obj->size);
+        LOG_TRACE ("-size: %u [RS] (@%" PRIuSIZE ".%u)\n",
+                   (unsigned)(BITCODE_RS)obj->size, dat->byte, dat->bit);
+        dat->byte = pos;
         SINCE (R_11)
         {
           BITCODE_RS crc = bit_calc_CRC (0xC0C1, &dat->chain[obj->address],

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -2394,7 +2394,7 @@ add_LTYPE_dashes (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
                 }
               bit_wcs2cpy ((BITCODE_TU)&o->strings_area[dash_i],
                            (BITCODE_TU)o->dashes[j].text);
-              dash_i += needed;
+              dash_i += (unsigned)needed;
             }
           else
             {
@@ -2405,7 +2405,7 @@ add_LTYPE_dashes (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
                   goto skip_overflow;
                 }
               strcpy ((char *)&o->strings_area[dash_i], o->dashes[j].text);
-              dash_i += needed;
+              dash_i += (unsigned)needed;
             }
         skip_overflow:;
         }


### PR DESCRIPTION
In encode_preR13_entities, the size patchup was skipped when obj->size was already non-zero. JSON import sets obj->size from the source file's entity sizes, but the encoder may write different amounts of data depending on flag_r11/opts_r11 computation (e.g. 2RD vs 3RD points for LINE entities based on FLAG_R11_HAS_ELEVATION). This caused entity size mismatches, decoder offset errors, and "Critical: INVALIDDWG" on the JSON roundtrip of R11 files like ACEB10.dwg.

Force size recalculation for all pre-R13 entities (dat->version < R_13b1) so the written size always matches the actual encoded data.

Fixes json-check r11/ACEB10 roundtrip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always recompute and rewrite the entity size for all pre‑R13 entities during encode after JSON import so the stored size matches the bytes actually written. Fixes R11 JSON roundtrip errors (size mismatches, decoder offsets, "INVALIDDWG"), e.g. ACEB10.dwg.

<sup>Written for commit dc39444a100e95a35560190b5db8972a7ce2845c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LibreDWG/libredwg/pull/1264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

