### PR TITLE
Fix PROXY_OBJECT version corruption in json roundtrip

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -6172,7 +6172,7 @@ DWG_OBJECT (PROXY_OBJECT)
   PRE (R_2018) {
     FIELD_BLx (version, 95);
     FIELD_VALUE (maint_version) = FIELD_VALUE(version) >> 8;
-    FIELD_VALUE (version) = FIELD_VALUE(version) & 0xff;
+    FIELD_VALUE (dwg_version) = FIELD_VALUE(version) & 0xff;
     LOG_TRACE ("> maint_version: %x\n", _obj->maint_version);
     LOG_TRACE ("> dwg_version: %x\n", _obj->dwg_version);
   }


### PR DESCRIPTION
The decoder for PROXY_OBJECT was overwriting the version field with just the low byte (dwg_version), discarding the maint_version high byte. This is a copy-paste error from PROXY_ENTITY, which correctly assigns to dwg_version instead of clobbering version.  The truncated version field (e.g. 15 instead of 527) caused ODA to throw "No ClassId" when reading the written DWG, breaking json-check roundtrips for any file containing a PROXY_OBJECT.

* src/dwg.spec (PROXY_OBJECT): Assign dwg_version from version low byte, matching PROXY_ENTITY behavior.