### PR TITLE
spike: prove Vercel Python Function can exec dwg2dxf built from source

### DIFF
--- a/api/healthz.py
+++ b/api/healthz.py
@@ -1,0 +1,74 @@
+"""
+GET /api/healthz — proves whether this Vercel Python Function can execute the
+LibreDWG `dwg2dxf` binary built from source during the Vercel build.
+
+Returns ONLY a redacted shape:
+  {"ok": true,  "converter": "available"}    (HTTP 200)  — `dwg2dxf --version` exited 0
+  {"ok": false, "converter": "unavailable"}  (HTTP 503)  — anything else
+
+Never exposes command output, stderr, file paths, environment variables, or
+secrets. This is a feasibility spike — no /convert, no app integration.
+"""
+
+import json
+import os
+import shutil
+import subprocess  # nosec B404 - fixed argv, no shell, bounded timeout
+import tempfile
+from http.server import BaseHTTPRequestHandler
+
+# The binary is staged next to this file under bin/ by build.sh and bundled via
+# vercel.json functions.includeFiles.
+_BUNDLED_BIN = os.path.join(os.path.dirname(os.path.abspath(__file__)), "bin", "dwg2dxf")
+
+
+def _converter_available():
+    """True iff the bundled dwg2dxf executes and `--version` exits 0."""
+    if not os.path.exists(_BUNDLED_BIN):
+        return False
+    # The function filesystem may be read-only or drop the execute bit, so copy
+    # the binary to a writable temp dir and mark it executable before exec.
+    tmpdir = tempfile.mkdtemp(prefix="dwg-")
+    try:
+        runnable = os.path.join(tmpdir, "dwg2dxf")
+        shutil.copy2(_BUNDLED_BIN, runnable)
+        os.chmod(runnable, 0o755)
+        env = dict(os.environ)
+        # If the binary is not fully static, let the loader find a co-bundled
+        # libredwg.so next to the original binary.
+        env["LD_LIBRARY_PATH"] = (
+            os.path.dirname(_BUNDLED_BIN) + ":" + env.get("LD_LIBRARY_PATH", "")
+        )
+        proc = subprocess.run(  # nosec B603 - fixed argv, no shell
+            [runnable, "--version"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,  # never surface converter output
+            timeout=5,
+            env=env,
+            check=False,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        ok = _converter_available()
+        body = json.dumps(
+            {"ok": True, "converter": "available"}
+            if ok
+            else {"ok": False, "converter": "unavailable"}
+        ).encode("utf-8")
+        self.send_response(200 if ok else 503)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args, **kwargs):
+        # Suppress default request logging (could echo paths). Redacted by design.
+        return

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Vercel buildCommand: compile dwg2dxf from THIS pinned source commit and stage
+# it for the Python function bundle. No binaries are committed to the repo.
+#
+# If the Vercel build image lacks the C toolchain (cmake / compiler), the build
+# fails here with a clear BLOCKED line — that is the feasibility answer.
+set -uo pipefail
+
+echo "== build.sh: toolchain probe =="
+for t in cc gcc make cmake perl; do
+  printf '  %s: ' "$t"; command -v "$t" || echo MISSING
+done
+cmake --version 2>/dev/null | head -1 || true
+
+# Vercel ("Other" framework) wants a static output directory to serve.
+mkdir -p public
+echo "libredwg vercel python feasibility spike" > public/index.html
+
+if ! command -v cmake >/dev/null 2>&1; then
+  echo "BLOCKED: cmake not present in the Vercel build image; cannot build LibreDWG from source." >&2
+  exit 1
+fi
+if ! command -v cc >/dev/null 2>&1 && ! command -v gcc >/dev/null 2>&1; then
+  echo "BLOCKED: no C compiler (cc/gcc) in the Vercel build image." >&2
+  exit 1
+fi
+
+set -e
+echo "== build.sh: configure (static) =="
+cmake -S . -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DLIBREDWG_LIBONLY=OFF
+
+echo "== build.sh: build dwg2dxf =="
+cmake --build build --target dwg2dxf -j 2
+
+mkdir -p api/bin
+BIN="$(find build -type f -name dwg2dxf | head -1)"
+if [ -z "${BIN}" ]; then
+  echo "BLOCKED: dwg2dxf binary was not produced by the build." >&2
+  exit 1
+fi
+cp "${BIN}" api/bin/dwg2dxf
+chmod 0755 api/bin/dwg2dxf
+# Co-bundle the shared lib in case the binary is not fully static.
+find build -name 'libredwg.so*' -exec cp {} api/bin/ \; 2>/dev/null || true
+
+echo "== build.sh: staged binary =="
+ls -la api/bin || true
+file api/bin/dwg2dxf 2>/dev/null || true
+ldd  api/bin/dwg2dxf 2>/dev/null || true
+echo "== build.sh: done =="

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "bash build.sh",
+  "outputDirectory": "public",
+  "functions": {
+    "api/healthz.py": {
+      "includeFiles": "api/bin/**"
+    }
+  }
+}


### PR DESCRIPTION
Feasibility spike only (no /convert, no app integration). Adds:
- api/healthz.py: GET /api/healthz copies the bundled dwg2dxf to a writable temp dir, chmod +x, runs `dwg2dxf --version` (5s timeout), returns a redacted {"ok":true,"converter":"available"} / unavailable. No output/paths/env leaked.
- build.sh: compiles dwg2dxf from this pinned commit during the Vercel build (static), stages it under api/bin for the function bundle; fails with a clear BLOCKED line if the build image lacks cmake/compiler. No binaries committed.
- vercel.json: buildCommand=build.sh, includeFiles api/bin into the function.