### PR TITLE
Potential fix for code scanning alert no. 179: Potential use after free

### DIFF
--- a/src/dwg2.spec
+++ b/src/dwg2.spec
@@ -1003,6 +1003,7 @@ DWG_OBJECT (TABLESTYLE)
     if (FIELD_VALUE (numoverrides))
       {
         FIELD_BL (unknown_bl3, 0);
+        memset (&ovr.cellstyle, 0, sizeof (ovr.cellstyle));
         CellStyle_fields (ovr.cellstyle);
         DXF { VALUE_TFF ("CELLSTYLE_BEGIN", 1) }
         FIELD_BL0 (ovr.id, 90);


### PR DESCRIPTION
Potential fix for [https://github.com/LibreDWG/libredwg/security/code-scanning/179](https://github.com/LibreDWG/libredwg/security/code-scanning/179)

General fix: ensure any structure passed into field-populating macros is in a known safe state (zero-initialized) before use, so no stale/dangling pointers are read or freed through macro-expanded code.

Best targeted fix here: in `src/dwg2.spec`, inside the `if (FIELD_VALUE (numoverrides))` block, explicitly clear `ovr.cellstyle` immediately before `CellStyle_fields (ovr.cellstyle);`. This preserves behavior (fields are then populated as before) while preventing use of previously freed pointers that may still be present in reused memory.

No new imports/dependencies are needed. The change is a single code edit in the shown block around lines 1005–1007.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
