### PR TITLE
Fix "Object handle not found" warnings in dwg_add_Document for pre-R2000

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -973,6 +973,9 @@ resolve_objectref_vector (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
       LOG_HANDLE ("-objref[%3ld]: HANDLE" FORMAT_REF "\n", (long)i,
                   ARGS_REF (ref));
       assert (ref->handleref.is_global == 1);
+      // skip code 0 refs (e.g. HANDSEED), they are handle values, not obj refs
+      if (ref->handleref.code == 0)
+        continue;
       // search the handle in all objects
       obj = dwg_resolve_handle (dwg, ref->absolute_ref);
       if (obj)
@@ -1023,7 +1026,7 @@ dwg_resolve_objectrefs_silent (Dwg_Data *restrict dwg)
     {
       // scan num_objects for the id (absolute_ref)
       Dwg_Object *restrict obj
-          = dwg_resolve_handle (dwg, dwg->object_ref[i]->absolute_ref);
+          = dwg_resolve_handle_silent (dwg, dwg->object_ref[i]->absolute_ref);
       dwg->object_ref[i]->obj = obj;
     }
   dwg->dirty_refs = 0;

--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -25208,7 +25208,9 @@ dwg_add_Document (Dwg_Data *restrict dwg, const int imperial)
           layer->color = (BITCODE_CMC){ 7, CMC_DEFAULTS };
           layer->ltype = dwg_add_handleref (dwg, 5, UINT64_C (0x16),
                                             NULL); // Continuous
-          layer->plotstyle = dwg_add_handleref (dwg, 5, UINT64_C (0xF), NULL);
+          if (version >= R_2000)
+            layer->plotstyle
+                = dwg_add_handleref (dwg, 5, UINT64_C (0xF), NULL);
           // CLAYER: (5.1.F) abs:F [H 8]
           dwg->header_vars.CLAYER
               = dwg_add_handleref (dwg, 5, UINT64_C (0x10), NULL);
@@ -25410,6 +25412,9 @@ dwg_add_Document (Dwg_Data *restrict dwg, const int imperial)
     {
       Dwg_Object_Ref *ref = dwg->object_ref[i];
       // possibly update the obj if realloced
+      // skip code 0 refs (e.g. HANDSEED), they are handle values, not obj refs
+      if (ref->handleref.code == 0)
+        continue;
       if ((obj = dwg_resolve_handle (dwg, ref->absolute_ref)))
         ref->obj = obj;
     }


### PR DESCRIPTION
Two issues caused spurious warnings when creating documents for r11 and
other pre-R2000 versions:

* src/dwg_api.c (dwg_add_Document): Skip resolving code-0 handle refs
  (e.g. HANDSEED) in the object_ref resolution loop.  Code-0 handles are
  handle values, not references to other objects, so resolving them as
  object references always fails with a warning.

* src/dwg_api.c (dwg_add_Document): Only set the default LAYER plotstyle
  to 0xF for R_2000 and later.  The PLOTSTYLE object at handle 0xF is only
  created for R_2000+, so referencing it in earlier versions caused an
  "Object handle not found" warning.  This aligns with dwg_add_LAYER,
  which already guards plotstyle assignment behind version >= R_2000.