### PR TITLE
Fix swapped MTEXT extents_width/extents_height for R2018 (#1278)

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3385,13 +3385,11 @@ DWG_ENTITY (MTEXT)
         }
         FIELD_BD (rect_width, 40);
         FIELD_BD (rect_height, 41);
-        DXF {
-          FIELD_BD (extents_width, 42);
-          FIELD_BD (extents_height, 43);
-        } else {
-          FIELD_BD (extents_height, 43);
-          FIELD_BD (extents_width, 42);
-        }
+        // GH #1278: the R2018 embedded MTEXT stores the extents width-first
+        // (1st double = width), same as DXF. (Earlier the binary was read
+        // height-first here, swapping width<->height for wide-and-short text.)
+        FIELD_BD (extents_width, 42);
+        FIELD_BD (extents_height, 43);
         // end redundant fields
 
         FIELD_BS (column_type, 71);

--- a/src/dwg_spec_shared.h
+++ b/src/dwg_spec_shared.h
@@ -696,8 +696,9 @@ free_3dsolid (Dwg_Object *restrict obj, Dwg_Entity_3DSOLID *restrict _obj)
   }                                                          \
   SUB_FIELD_BS (mtext, attachment, 71);                      \
   SUB_FIELD_BS (mtext, flow_dir, 72);                        \
-  SUB_FIELD_BD (mtext, extents_height, 43);                  \
+  /* GH #1278: R2018-only embedded MTEXT stores extents width-first */ \
   SUB_FIELD_BD (mtext, extents_width, 42);                   \
+  SUB_FIELD_BD (mtext, extents_height, 43);                  \
   SUB_FIELD_T (mtext, text, 1);                              \
   SUB_FIELD_HANDLE0 (mtext, style, 5, 7);                    \
   SUB_FIELD_BS (mtext, linespace_style, 73);                 \


### PR DESCRIPTION
Fixes the R2018 (AC1032) MTEXT `extents_width`/`extents_height` swap reported in #1278.

## Problem

For R2018, a wide-and-short MTEXT is decoded with width and height swapped — e.g. a text that is ~124 wide × 26 tall comes out as `extents_width=26.14, extents_height=124.09`. AutoCAD reversed the on-disk extents order somewhere in (R2013 … R2018]; the DXF group codes (`42` = width ≤ `41`, `43` = height) are already correct — only the **binary field order** was wrong.

## Root cause

The visible swap comes from the R2018-only **embedded** MTEXT object (`AcDbMTextObjectEmbedded`), which read the two extents doubles **height-first**. The plain MTEXT extents (`src/dwg.spec` ~3343) already read correctly and are overwritten by the embedded "redundant fields" block, so the fix is in the embedded paths:

- `src/dwg.spec`: the `SINCE (R_2018)` `is_not_annotative` embedded block read the binary height-first (DXF was width-first) — now **width-first** for both.
- `src/dwg_spec_shared.h`: `AcDbMTextObjectEmbedded` (also used by R2018 multiline `ATTRIB`) — now **width-first**.

The `FIELD_BD`/`SUB_FIELD_BD` macros are bidirectional, so decode and encode are fixed together. Both paths are R2018-only, so R2013-and-earlier MTEXT is untouched and no version gate is needed.

## Verification

On an R2018 drawing with a wide MTEXT, `dwgread -O JSON` now reports `extents_width≈124.09 / extents_height≈26.14` (was swapped), with `extents_width ≤ rect_width`, and the plain and embedded extents now agree. A `dwgrewrite --as r2018` round-trip is stable.
