### PR TITLE
R2018 write/encode fidelity: object loss, thumbnail, DXF UTF-8/codepage, MTEXT, LAYER colour

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -2282,25 +2282,63 @@ bit_write_T (Bit_Chain *restrict dat, BITCODE_T restrict s)
               const char *endp = s + len;
               BITCODE_TU ws = (BITCODE_TU)malloc ((len + 1) * 2);
               const BITCODE_TU orig = ws;
+              // DXF in-memory strings are UTF-8 (in_dxf keeps them as read);
+              // decode multi-byte sequences to UTF-16 so non-ASCII is not
+              // double-encoded by a bare byte copy. Other producers of TV here
+              // (JSON, add API, old-DWG up-convert) already hold codepage bytes
+              // with non-representable chars as \U+xxxx escapes, so they keep
+              // the byte-wise path. Both honour the inline \U+xxxx escape.
+              const bool is_utf8 = (dat->opts & DWG_OPTS_INDXF) != 0;
               while (s < endp)
                 {
-                  uint16_t c = *s++;
-                  // in this case the resulting len is shorter
-                  if (c == '\\' && s[0] == 'U' && s[1] == '+' && ishex (s[2])
-                      && ishex (s[3]) && ishex (s[4]) && ishex (s[5]))
+                  unsigned char c = (unsigned char)*s;
+                  // \U+xxxx escape: shorter result
+                  if (c == '\\' && s + 6 < endp + 1 && s[1] == 'U'
+                      && s[2] == '+' && ishex (s[3]) && ishex (s[4])
+                      && ishex (s[5]) && ishex (s[6]))
                     {
                       unsigned x;
-                      if (sscanf (&s[2], "%04X", &x) > 0)
+                      if (sscanf (&s[3], "%04X", &x) > 0)
                         {
-                          // fprintf (stderr, "* sscanf: 0x%04X\n", x);
-                          *ws++ = x;
-                          s += 6;
+                          *ws++ = (uint16_t)x;
+                          s += 7;
+                          continue;
                         }
-                      else
-                        *ws++ = c;
                     }
-                  else
-                    *ws++ = c;
+                  if (!is_utf8 || c < 0x80)
+                    {
+                      *ws++ = c;
+                      s++;
+                    }
+                  else if ((c & 0xe0) == 0xc0 && s + 1 < endp)
+                    {
+                      *ws++ = (uint16_t)(((c & 0x1f) << 6) | (s[1] & 0x3f));
+                      s += 2;
+                    }
+                  else if ((c & 0xf0) == 0xe0 && s + 2 < endp)
+                    {
+                      *ws++ = (uint16_t)(((c & 0x0f) << 12)
+                                         | ((s[1] & 0x3f) << 6)
+                                         | (s[2] & 0x3f));
+                      s += 3;
+                    }
+                  else if ((c & 0xf8) == 0xf0 && s + 3 < endp)
+                    {
+                      // 4-byte UTF-8 -> UTF-16 surrogate pair
+                      uint32_t cp = ((uint32_t)(c & 0x07) << 18)
+                                    | ((uint32_t)(s[1] & 0x3f) << 12)
+                                    | ((uint32_t)(s[2] & 0x3f) << 6)
+                                    | (uint32_t)(s[3] & 0x3f);
+                      cp -= 0x10000;
+                      *ws++ = (uint16_t)(0xD800 + (cp >> 10));
+                      *ws++ = (uint16_t)(0xDC00 + (cp & 0x3FF));
+                      s += 4;
+                    }
+                  else // invalid byte: pass through
+                    {
+                      *ws++ = c;
+                      s++;
+                    }
                 }
               *ws = 0;
               // bit_write_TU (dat, orig);

--- a/src/common.h
+++ b/src/common.h
@@ -622,8 +622,12 @@ void *my_memmem (const void *h0, size_t k, const void *n0, size_t l)
 /* HAVE_MEMMEM and _GNU_SOURCE are unreliable on non-Linux systems.
    This fails on FreeBSD and macos.
    Rather declare it by ourselves, and don't use _GNU_SOURCE. */
+/* macOS already declares memmem() in <string.h>; redeclaring it trips
+   -Werror=redundant-decls. */
+#  if !defined(__APPLE__)
 void *memmem (const void *h0, size_t k, const void *n0, size_t l)
     __nonnull ((1, 3));
+#  endif
 #endif
 
 // push to handle vector at the end. It really is unshift.

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3385,13 +3385,11 @@ DWG_ENTITY (MTEXT)
         }
         FIELD_BD (rect_width, 40);
         FIELD_BD (rect_height, 41);
-        DXF {
-          FIELD_BD (extents_width, 42);
-          FIELD_BD (extents_height, 43);
-        } else {
-          FIELD_BD (extents_height, 43);
-          FIELD_BD (extents_width, 42);
-        }
+        // GH #1278: the R2018 embedded MTEXT stores the extents width-first
+        // (1st double = width), same as DXF. (Earlier the binary was read
+        // height-first here, swapping width<->height for wide-and-short text.)
+        FIELD_BD (extents_width, 42);
+        FIELD_BD (extents_height, 43);
         // end redundant fields
 
         FIELD_BS (column_type, 71);

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3820,8 +3820,11 @@ DWG_TABLE (LAYER)
       if (FIELD_VALUE (color.index) == 256) {
         FIELD_VALUE (color.index) = FIELD_VALUE (color.rgb) & 0xFF;
       }
-      // Negative value in case of disabled layer
-      FIELD_VALUE (color.index) = - FIELD_VALUE(color.index);
+      // A negative DXF group-62 colour means the layer is off; only negate
+      // when the layer is actually off, otherwise an on layer is exported as
+      // off and its entities become invisible.
+      if (FIELD_VALUE (off))
+        FIELD_VALUE (color.index) = - FIELD_VALUE (color.index);
     }
     FIELD_CMC (color, 62);
   }

--- a/src/dwg_spec_shared.h
+++ b/src/dwg_spec_shared.h
@@ -696,8 +696,9 @@ free_3dsolid (Dwg_Object *restrict obj, Dwg_Entity_3DSOLID *restrict _obj)
   }                                                          \
   SUB_FIELD_BS (mtext, attachment, 71);                      \
   SUB_FIELD_BS (mtext, flow_dir, 72);                        \
-  SUB_FIELD_BD (mtext, extents_height, 43);                  \
+  /* GH #1278: R2018-only embedded MTEXT stores extents width-first */ \
   SUB_FIELD_BD (mtext, extents_width, 42);                   \
+  SUB_FIELD_BD (mtext, extents_height, 43);                  \
   SUB_FIELD_T (mtext, text, 1);                              \
   SUB_FIELD_HANDLE0 (mtext, style, 5, 7);                    \
   SUB_FIELD_BS (mtext, linespace_style, 73);                 \

--- a/src/encode.c
+++ b/src/encode.c
@@ -1980,12 +1980,27 @@ encode_r13_thumbnail (Dwg_Data *restrict dwg, Bit_Chain *restrict dat,
         LOG_TRACE ("Thumbnail size: 5 [RL]\n");
         bit_write_RC (dat, 0); // num_pictures
         LOG_TRACE ("Thumbnail num_pictures: 0 [RC]\n");
+        write_sentinel (dat, DWG_SENTINEL_THUMBNAIL_END);
       }
     else
       {
-        bit_write_TF (dat, dwg->thumbnail.chain, dwg->thumbnail.size);
+        // thumbnail.byte is the offset to the image data: 0 for r13-r2000
+        // (chain points past the BEGIN sentinel) and 16 for r2004+ (chain is
+        // the section base, kept as the freeable pointer). We emit our own
+        // BEGIN sentinel above, so write only the size bytes of content.
+        bit_write_TF (dat, dwg->thumbnail.chain + dwg->thumbnail.byte,
+                      dwg->thumbnail.size);
+        // For r2004+ the decoder keeps the trailing END sentinel inside
+        // thumbnail.size (decode.c: size = sec_dat.size - 16, byte = 16; the
+        // JSON writer likewise retains it), so it was just emitted as part of
+        // the content above. Adding a second one would grow the Preview
+        // section by 16 bytes on every round-trip. For r13-r2000 the END
+        // sentinel is separate from thumbnail.size, so it must be written.
+        PRE (R_2004a)
+        {
+          write_sentinel (dat, DWG_SENTINEL_THUMBNAIL_END);
+        }
       }
-    write_sentinel (dat, DWG_SENTINEL_THUMBNAIL_END);
     {
       BITCODE_RL bmpsize;
       BITCODE_RC type;
@@ -6217,15 +6232,18 @@ dwg_encode_add_object (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
       error = dwg_encode_PROXY_OBJECT (dat, obj);
       break;
     case DWG_TYPE_UNKNOWN_ENT:
-      if ((dwg->opts & DWG_OPTS_INJSON)
-          && dwg->header.version == dwg->header.from_version)
+      // We can re-emit the raw class blob verbatim whenever we still hold it
+      // (decoded from DWG or imported from JSON) and the target version equals
+      // the source version, so the bit layout is unchanged.
+      if (dwg->header.version == dwg->header.from_version && obj->unknown_bits
+          && obj->num_unknown_bits)
         error = dwg_encode_raw_UNKNOWN_ENT (dat, obj);
       else
         error = DWG_ERR_UNHANDLEDCLASS;
       break;
     case DWG_TYPE_UNKNOWN_OBJ:
-      if ((dwg->opts & DWG_OPTS_INJSON)
-          && dwg->header.version == dwg->header.from_version)
+      if (dwg->header.version == dwg->header.from_version && obj->unknown_bits
+          && obj->num_unknown_bits)
         error = dwg_encode_raw_UNKNOWN_OBJ (dat, obj);
       else
         error = DWG_ERR_UNHANDLEDCLASS;

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -11154,28 +11154,39 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
                 LOG_WARN ("Unhandled LAYOUT.1 in subclass %s", subclass);
               goto next_pair;
             }
-          else if (pair->code == 3 && obj->fixedtype == DWG_TYPE_MTEXT)
+          else if ((pair->code == 3 || pair->code == 1)
+                   && obj->fixedtype == DWG_TYPE_MTEXT)
             {
+              // MTEXT text > 250 chars is split into 250-char chunks: the
+              // leading chunks use code 3 and the final (< 250) chunk uses
+              // code 1. Concatenate them in order (a short MTEXT has only the
+              // code 1). The previous code overwrote instead of appending, so
+              // only the last chunk survived.
               Dwg_Entity_MTEXT *o = obj->tio.entity->tio.MTEXT;
               size_t len = strlen (pair->value.s.ptr);
               if (!o->text)
                 {
                   o->text = strdup (pair->value.s.ptr);
                   written = len;
-                  LOG_TRACE ("MTEXT.text = %s (%" PRIuSIZE ") [TV 3]\n",
-                             pair->value.s.ptr, len);
+                  LOG_TRACE ("MTEXT.text = %s (%" PRIuSIZE ") [TV %d]\n",
+                             pair->value.s.ptr, len, pair->code);
                 }
               else
                 {
-                  assert (o->text);
-                  if (strlen (o->text) < len)
-                    o->text = (char *)realloc (o->text, len + 1);
-                  strcpy (o->text, pair->value.s.ptr);
-                  written += len;
-                  LOG_TRACE ("MTEXT.text += %" PRIuSIZE "/%" PRIuSIZE
-                             " [TV 3]\n",
-                             len, written);
+                  size_t oldlen = strlen (o->text);
+                  char *newtext
+                      = (char *)realloc (o->text, oldlen + len + 1);
+                  if (newtext)
+                    {
+                      o->text = newtext;
+                      memcpy (o->text + oldlen, pair->value.s.ptr, len + 1);
+                      written = oldlen + len;
+                    }
+                  LOG_TRACE ("MTEXT.text += %" PRIuSIZE " => %" PRIuSIZE
+                             " [TV %d]\n",
+                             len, written, pair->code);
                 }
+              goto next_pair;
             }
           /*
           else if (pair->code == 2 && obj->fixedtype == DWG_TYPE_LAYOUT)

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -645,7 +645,10 @@ dxf_read_string (Bit_Chain *dat, char **string)
   else
     {
       int i;
-      dxf_skip_ws (dat);
+      // Do not skip leading whitespace here: dxf_read_rs already consumed the
+      // group-code line incl. its newline, so we are positioned at the start of
+      // the value line, and leading spaces in a string value are significant
+      // (e.g. an MTEXT continuation chunk that begins with a space).
       if (dat->byte >= dat->size
           || !memchr (&dat->chain[dat->byte], '\n', dat->size - dat->byte))
         return;
@@ -1656,26 +1659,41 @@ dxf_set_DWGCODEPAGE (Bit_Chain *dat, Dwg_Data *dwg)
 {
   Dwg_Header_Variables *vars = &dwg->header_vars;
   Dwg_Header *hdr = &dwg->header;
+  char *cp_tmp = NULL;
+  const char *cp_str;
 
   if (!vars->DWGCODEPAGE)
     return;
+  // r2007+ stores header TV strings as TU (UTF-16); decode to UTF-8 for the
+  // textual codepage-name lookup, otherwise only the first byte is seen (e.g.
+  // "ANSI_1252" reads as "A") and the codepage is wrongly UNDEFINED. Detect TU
+  // by the embedded NUL — codepage names are pure ASCII, so a UTF-16LE copy has
+  // a 0 second byte, whereas a plain UTF-8 name does not. (Keyed on the actual
+  // bytes, not from_version, since a down-convert may already have re-encoded
+  // the header strings to UTF-8.)
+  if (vars->DWGCODEPAGE[0] && vars->DWGCODEPAGE[1] == 0)
+    cp_str = cp_tmp = bit_convert_TU ((BITCODE_TU)vars->DWGCODEPAGE);
+  else
+    cp_str = vars->DWGCODEPAGE;
+  if (!cp_str)
+    return;
   // r11 usually has "undefined"
-  if (hdr->from_version <= R_12 && strEQc (vars->DWGCODEPAGE, "undefined"))
+  if (hdr->from_version <= R_12 && strEQc (cp_str, "undefined"))
     hdr->codepage = CP_UNDEFINED;
   else
     {
-      hdr->codepage = dwg_codepage_int (vars->DWGCODEPAGE);
+      hdr->codepage = dwg_codepage_int (cp_str);
       if (hdr->codepage == CP_UNDEFINED)
         {
-          LOG_ERROR ("Invalid DWGCODEPAGE %s", vars->DWGCODEPAGE);
+          LOG_ERROR ("Invalid DWGCODEPAGE %s", cp_str);
         }
       else
         {
-          LOG_TRACE ("HEADER.codepage = %u [%s]\n", hdr->codepage,
-                     vars->DWGCODEPAGE);
+          LOG_TRACE ("HEADER.codepage = %u [%s]\n", hdr->codepage, cp_str);
           dat->codepage = hdr->codepage;
         }
     }
+  free (cp_tmp);
 }
 
 static void


### PR DESCRIPTION
A series of fidelity fixes for the modern (R2018 / AC1032) read↔write paths, found while round-tripping real R2018 drawings.

### Commits

1. **Fix swapped MTEXT extents for R2018 (#1278)** — embedded MTEXT extents read width-first. Also submitted standalone as #1279 (this branch is based on it).
2. **encode: fix R2018 decode→encode→decode object loss + thumbnail growth** — `UNKNOWN_OBJ`/`UNKNOWN_ENT` proxy blobs were dropped on a same-version DWG→DWG re-encode (the raw re-emit was gated on `DWG_OPTS_INJSON`; now also for DWG input), and the `AcDb:Preview` thumbnail grew 16 bytes per round-trip (a duplicate `THUMBNAIL_END` sentinel). `example_2018` now round-trips 474/474 objects with a byte-identical, stable thumbnail.
3. **in_dxf: concatenate MTEXT text split across group codes 3 and 1** — long MTEXT text (>250 chars) was overwritten chunk-by-chunk and truncated to one fragment on import; now concatenated.
4. **bits: decode UTF-8 DXF strings to UTF-16 when encoding to r2007+** — DXF (UTF-8) strings were zero-extended byte-wise when written to an r2007+ target, double-encoding non-ASCII (`été`→`Ã©tÃ©`); now decoded as real UTF-8, gated on `DWG_OPTS_INDXF` so the JSON/add-API codepage paths are unchanged.
5. **in_dxf: preserve leading spaces in string values; fix r2007+ DWGCODEPAGE read** — `dxf_read_string` stripped significant leading spaces (breaking MTEXT continuations), and `DWGCODEPAGE` (a `BITCODE_TV`, i.e. UTF-16 for r2007+) was read as a C string so `ANSI_1252` was seen as `A`.
6. **out_dxf: only negate LAYER colour (DXF 62) when the layer is off** — the exporter unconditionally negated group-62, so layers that are **on** were exported as **off** (their entities became invisible, and a DWG→DXF→DWG round-trip flipped them off); now negated only when `off`.
7. **build: don't redeclare memmem() on macOS** — small build fix (macOS declares `memmem()` in `<string.h>`, tripping `-Werror=redundant-decls`).

### Testing

Verified against real R2018 files and the test corpus via DWG→DWG (`dwgrewrite`), DXF (`dwg2dxf | dxf2dwg`), and JSON round-trips: no object loss, byte-identical MTEXT/accented text, stable thumbnail, correct LAYER on/off. Existing r13–r2000 paths are unaffected.

### Note on overlap

Commit 1 is the #1278 fix, also opened as the smaller standalone PR #1279; this branch includes it as its base so the encoder work builds on it. Once #1279 lands, this branch can be rebased to drop the duplicate.
