### PR TITLE
out_dxf: only negate LAYER colour (DXF 62) when the layer is off

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3822,8 +3822,11 @@ DWG_TABLE (LAYER)
       if (FIELD_VALUE (color.index) == 256) {
         FIELD_VALUE (color.index) = FIELD_VALUE (color.rgb) & 0xFF;
       }
-      // Negative value in case of disabled layer
-      FIELD_VALUE (color.index) = - FIELD_VALUE(color.index);
+      // A negative DXF group-62 colour means the layer is off; only negate
+      // when the layer is actually off, otherwise an on layer is exported as
+      // off and its entities become invisible.
+      if (FIELD_VALUE (off))
+        FIELD_VALUE (color.index) = - FIELD_VALUE (color.index);
     }
     FIELD_CMC (color, 62);
   }


### PR DESCRIPTION
The LAYER table writer unconditionally negated the group-62 colour index.
A negative DXF 62 means "layer off", so every on layer was exported as off
and its entities became invisible after dwg2dxf (a DWG→DXF→DWG round-trip
would flip the layer off and lose its colour). libredwg's own decoder
reported the layer as on, so this was purely an exporter inconsistency.

Take the sign from the decoded `off` flag (derived from flag0 & 2 for
r2000+, read directly for r13-r14): negate only when off. An on layer now
exports its true positive ACI (e.g. 62=7 instead of -7) and the DWG→DXF→DWG
round-trip preserves the layer-on state; an off layer still exports negative.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
