### PR TITLE
decode: fix R2004+ decompression aborting on exact buffer-fill (data loss)

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -1284,12 +1284,14 @@ decompress_R2004_section (Bit_Chain *restrict src, Bit_Chain *restrict dec)
       pos = dec->byte;
       LOG_INSANE ("co: %d %ld->%" PRIuSIZE "\n", comp_bytes,
                   (long)pos - comp_offset, pos);
-      // This seems to be a comp_bytes encoding bug,
-      // copying past the decompressed_size. rather cap it and stop
-      // decompression. ACadSharp decompresses all comp_bytes, enlarging the
-      // buffer (but not using it)
+      // A final back-reference may legitimately fill the buffer exactly to
+      // dec->size (the trailing copy lands in the unused tail past the real
+      // page data and is never read). 0.13.3 allowed this (dst + comp_bytes >
+      // dst_end); the refactor's `>=` rejected the exact-fill case and aborted
+      // the whole section mid-stream, dropping/garbling thousands of objects
+      // on real R2018 files. Only error when the copy would overrun the buffer.
       end = pos + comp_bytes;
-      if (end >= dec->size || (long)pos < comp_offset
+      if (end > dec->size || (long)pos < comp_offset
           || (size_t)(pos - comp_offset) >= dec->size
           || (size_t)comp_offset > dec->size)
         {


### PR DESCRIPTION
decompress_R2004_section rejected a back-reference copy whose end landed
*exactly* on the decompressed buffer size (`end >= dec->size`). A real R2018
section legitimately ends with a copy that fills the buffer to the brim (the
trailing run lands in the unused tail past the page's real data and is never
read), so this false positive aborted the whole section mid-stream with
"Invalid decompression bytes". The short section then left every later
bit_read run off the end, dropping/garbling thousands of objects — a
regression vs 0.13.3 introduced by the 2004-decompression refactor (the
pre-refactor code used `dst + comp_bytes > dst_end`, i.e. strict `>`).

Restore the strict comparison (`end > dec->size`): only error when the copy
would actually overrun the buffer; allow the exact-fill case. The copy then
writes at most dec->size bytes (buffer is over-allocated by 1024), so this is
still safe against OOB.

On a real R2018 file that previously hit 5+ "Invalid decompression bytes"
and produced unusable JSON, the decode is now clean (0 errors) and recovers
the same 121 objects as 0.13.3. r2004–r2018 corpus decode unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
