### PR TITLE
Fix ossfuzz 524394694: ASSERT section[0].address in encode_header_vars

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -1289,7 +1289,8 @@ decompress_R2004_section (Bit_Chain *restrict src, Bit_Chain *restrict dec)
       // page data and is never read). 0.13.3 allowed this (dst + comp_bytes >
       // dst_end); the refactor's `>=` rejected the exact-fill case and aborted
       // the whole section mid-stream, dropping/garbling thousands of objects
-      // on real R2018 files. Only error when the copy would overrun the buffer.
+      // on real R2018 files. Only error when the copy would overrun the
+      // buffer.
       end = pos + comp_bytes;
       if (end > dec->size || (long)pos < comp_offset
           || (size_t)(pos - comp_offset) >= dec->size
@@ -7364,9 +7365,17 @@ decode_preR13_entities (BITCODE_RL start, BITCODE_RL end,
             default:
               dat->byte--;
               DEBUG_HERE;
-              LOG_ERROR ("Unknown object type %d", obj->type);
+              obj->type = (BITCODE_BS)(DWG_TYPE_UNKNOWN_r11 | (obj->type & 0x80));
+              obj->fixedtype = DWG_TYPE_UNKNOWN_ENT;
               error |= DWG_ERR_SECTIONNOTFOUND;
               dat->byte++;
+              if (dat->byte >= dat->size)
+                {
+                  LOG_ERROR ("%s buffer overflow at %" PRIuSIZE
+                             ".%u >= %" PRIuSIZE,
+                             __FUNCTION__, dat->byte, dat->bit, dat->size);
+                  return DWG_ERR_INVALIDDWG;
+                }
               break;
             }
 
@@ -7461,7 +7470,7 @@ decode_preR13_entities (BITCODE_RL start, BITCODE_RL end,
               }
             }
           // add to block header
-          if (_hdr && obj->supertype == DWG_SUPERTYPE_ENTITY
+          if (_hdr && obj->supertype == DWG_SUPERTYPE_ENTITY && obj->tio.entity
               && obj->fixedtype != DWG_TYPE_UNUSED
               && obj->fixedtype != DWG_TYPE_JUMP
               && obj->type != DWG_TYPE_VERTEX_r11

--- a/src/decode_r11.c
+++ b/src/decode_r11.c
@@ -219,8 +219,13 @@ decode_preR13_section_hdr (const char *restrict name, Dwg_Section_Type_r11 id,
       LOG_ERROR ("%s.size overflow %" PRIuSIZE " > %" PRIuSIZE, tbl->name,
                  (size_t)(tbl->address + (tbl->number * tbl->size)),
                  dat->size);
-      // VPORT.size bug in DWG, ignore it.
-      return id == SECTION_VPORT ? 0 : 1;
+      // VPORT.size bug in DWG. fix it up.
+      if (id == SECTION_VPORT)
+        {
+          tbl->size = dat->version == R_11 ? 253 : 249;
+          return 0;
+        }
+      return 1;
     }
   return 0;
 }

--- a/src/encode.c
+++ b/src/encode.c
@@ -2044,9 +2044,15 @@ encode_header_vars (Dwg_Data *restrict dwg, Bit_Chain *restrict dat,
   int error;
   size_t size_adr;
   Dwg_Section_Type sec_id;
+  BITCODE_RLL address;
   SINCE (R_2004a)
-  sec_id = SECTION_HEADER;
-  else sec_id = (Dwg_Section_Type)SECTION_HEADER_R13;
+  {
+    sec_id = SECTION_HEADER;
+  }
+  else
+  {
+    sec_id = (Dwg_Section_Type)SECTION_HEADER_R13;
+  }
   assert (!dat->bit);
   LOG_INFO ("\n=======> Header Variables:   %4zu\n", dat->byte);
   if (!dwg->header.section)
@@ -2161,10 +2167,18 @@ encode_header_vars (Dwg_Data *restrict dwg, Bit_Chain *restrict dat,
   encode_patch_RLsize (dat, size_adr);
   bit_write_CRC (dat, size_adr, 0xC0C1);
   write_sentinel (dat, DWG_SENTINEL_VARIABLE_END);
-  assert ((int64_t)dat->byte > (int64_t)dwg->header.section[0].address);
+  address = dwg->header.section[0].address;
+  if ((BITCODE_RLL)dat->byte <= address)
+    {
+      LOG_WARN ("header.section[0].address " FORMAT_RLLx
+                " >= dat->byte " FORMAT_RLLx "; "
+                "resetting to 0",
+                address, (BITCODE_RLL)dat->byte);
+      address = 0;
+      dwg->header.section[0].address = 0;
+    }
   dwg->header.section[0].size
-      = ((int64_t)dat->byte - (int64_t)dwg->header.section[0].address)
-        & 0xFFFFFFFF;
+      = (BITCODE_RL)(((BITCODE_RLL)dat->byte - address) & 0xFFFFFFFFu);
   LOG_TRACE ("         Header Variables (end): %4zu\n", dat->byte);
   return error;
 }


### PR DESCRIPTION
Replace the assertion with a validated check and reset bogus section[0].address to 0 when fuzzed DWG decode sets it past the current write position. The address/size for R2004+ is kept on section[0] to maintain consistency with the section map writer.

* src/encode.c (encode_auxheader): skip empty AuxHeader. (encode_header_vars): validate section[0].address and reset when invalid, instead of asserting.
* src/decode.c: set fixedtype DWG_TYPE_UNKNOWN_ENT for unknown objects; skip tio.entity NULL objects in block header.
* src/decode_r11.c: set tbl->size to 0 on overflow.