### PR TITLE
out_dxf: only negate LAYER colour (DXF 62) when the layer is off

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -3817,8 +3817,15 @@ DWG_TABLE (LAYER)
       if (FIELD_VALUE (color.index) == 256) {
         FIELD_VALUE (color.index) = FIELD_VALUE (color.rgb) & 0xFF;
       }
-      // Negative value in case of disabled layer
-      FIELD_VALUE (color.index) = - FIELD_VALUE(color.index);
+      // DXF group 62 is negative iff the layer is off. Derive the sign from
+      // the decoded `off` flag, using abs() so an already-signed index cannot
+      // double-negate. Previously this negated unconditionally, exporting an
+      // ON layer as OFF (its entities became invisible).
+      if (FIELD_VALUE (off)) {
+        FIELD_VALUE (color.index) = -abs (FIELD_VALUE (color.index));
+      } else {
+        FIELD_VALUE (color.index) = abs (FIELD_VALUE (color.index));
+      }
     }
     FIELD_CMC (color, 62);
   }


### PR DESCRIPTION
The LAYER table writer negated the group-62 colour index unconditionally, so
every ON layer was exported with a negative 62 (= "layer off") and its
entities became invisible after dwg2dxf; a DWG->DXF->DWG round-trip flipped
the layer off. libredwg's own decoder reports the layer as on, so this was an
exporter-only inconsistency.

Derive the sign from the decoded `off` flag: negate only when off, using
abs() so an already-signed index cannot double-negate, with explicit braces.
An ON layer now exports its true positive ACI (62=7 instead of -7) and an OFF
layer exports negative; the DWG->DXF->DWG round-trip preserves on/off.

This re-applies the fix from the earlier #1283 (which did not land on master)
and incorporates the review feedback there (sign via -abs(), braces).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
