### PR TITLE
bits: fix misleading CWE-120 comment on in_hex2bin reference path

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -4557,11 +4557,13 @@ size_t
 in_hex2bin (unsigned char *restrict dest, char *restrict src, size_t destlen)
 {
 #if 0
+  // Reference implementation (the #else lookup path below is what's used).
+  // Decodes two hex nibbles per byte by hand, without scanf; assumes src holds
+  // at least 2*destlen hex chars per the caller's contract (a non-hex char,
+  // incl. NUL, stops early and returns the count decoded so far).
   char *pos = (char *)src;
   for (size_t i = 0; i < destlen; i++)
     {
-      // Safe alternative to sscanf (pos, "%2hhX", &dest[i]) (CWE-120): decode
-      // exactly two hex nibbles by hand, no format string.
       unsigned char b = 0;
       for (int n = 0; n < 2; n++)
         {


### PR DESCRIPTION
The disabled (#if 0) reference implementation of in_hex2bin carried a
"Safe alternative to sscanf ... (CWE-120)" comment, but the relevant concern
for that hand-rolled loop is an out-of-bounds read, not a format-string
overflow, and the active implementation is the #else lookup path. Reword the
comment to describe it accurately (reference-only; relies on the caller's
2*destlen contract) and drop the misleading security justification.

Addresses review feedback on #1282.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
