### PR TITLE
dxf: VIEWPORT frozen_layers should use group code 331, not 341

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -2523,11 +2523,11 @@ DWG_ENTITY (VIEWPORT)
     FIELD_HANDLE (vport_entity_header, 5, 0); // => VX
   }
   VERSIONS (R_2000b, R_2002) {
-    HANDLE_VECTOR (frozen_layers, num_frozen_layers, 5, 341);
+    HANDLE_VECTOR (frozen_layers, num_frozen_layers, 5, 331);
     FIELD_HANDLE (clip_boundary, 5, 340);
   }
   SINCE (R_2004a) {
-    HANDLE_VECTOR (frozen_layers, num_frozen_layers, 4, 341);
+    HANDLE_VECTOR (frozen_layers, num_frozen_layers, 4, 331);
     FIELD_HANDLE (clip_boundary, 5, 340);
   }
   VERSIONS (R_2000b, R_2002) {


### PR DESCRIPTION
### Problem
`dwg2dxf` output has **empty per-viewport frozen-layer lists** when read by spec-conformant DXF parsers (e.g. ezdxf `Viewport.frozen_layers`, AutoCAD), even though the source DWG has them. DWG decode and `dwgread -O JSON` are correct, so the data is read fine — it is written to DXF under the wrong group code.

### Root cause
In `src/dwg.spec`, the `VIEWPORT` `frozen_layers` `HANDLE_VECTOR` emits DXF group code **341** in both the R2000–R2002 and R2004+ branches:

```
HANDLE_VECTOR (frozen_layers, num_frozen_layers, 5, 341);   // R2000–R2002
HANDLE_VECTOR (frozen_layers, num_frozen_layers, 4, 341);   // R2004+
```

341 is the hard-pointer band (matching the adjacent `clip_boundary`=340 / `visualstyle`=348). But per the AutoCAD DXF reference, `AcDbViewport` frozen-layer object handles are **331** (soft-pointer). So the handles are emitted under the wrong code, and parsers scanning for 331 find none. Decode/`-O JSON` are unaffected because they serialize by field name, not DXF code — which is also why libredwg's own symmetric DWG↔DXF round-trip never surfaced it.

### Fix
Change the `frozen_layers` DXF group code `341 → 331` in both version branches.

### Verification
On a multi-sheet construction DWG, sheet `260`'s content viewport:
- **before:** ezdxf `Viewport.frozen_layers == []`
- **after:** all 9 frozen layers read correctly (`0`, `I-floor`, `I-CEILING`, `E-LIGHT`, `SW049-200|T-文字`, …) — an exact match to `dwgread -O JSON`'s `frozen_layers`.
