### PR TITLE
Fix UBSan pointer-overflow in bsearch_ex on empty array

### DIFF
--- a/src/dwg.c
+++ b/src/dwg.c
@@ -3891,7 +3891,7 @@ bsearch_ex (const void *pKey, const void *pBase, size_t numBase,
 {
   size_t numNow = numBase;
   char *pLo = (char *)pBase;
-  char *pHi = (char *)pBase + (numNow - 1) * nItemWidth;
+  char *pHi;
   if (NULL != ppBefore)
     {
       *ppBefore = NULL;
@@ -3900,6 +3900,7 @@ bsearch_ex (const void *pKey, const void *pBase, size_t numBase,
     {
       return NULL;
     }
+  pHi = (char *)pBase + (numNow - 1) * nItemWidth;
   for (; pLo <= pHi;)
     {
       if (0 == numNow)


### PR DESCRIPTION
UBSan, clang -fsanitize=undefined:

    src/dwg.c:3894:29: runtime error: addition of unsigned offset to 0x1080b0800 overflowed to 0x1080b07f8
        #0 ordered_ref_add dwg.c:4026
        #1 dwg_add_handleref dwg.c:2259
        #2 dwg_encode encode.c:3043

bsearch_ex computes pHi = pBase + (numNow - 1) * nItemWidth before the
0 == numBase guard. On the first dwg_add_handleref for an untrusted file the
ordered-ref array is still empty, so numNow is 0, numNow - 1 wraps to SIZE_MAX
and the pointer arithmetic overflows. Move the pHi computation past the early
return so it only runs once the array is known non-empty.
