### PR TITLE
fix double-free in free_TABLESTYLE_r2010 on downconvert

### DIFF
--- a/src/free.c
+++ b/src/free.c
@@ -642,9 +642,10 @@ free_TABLESTYLE_r2010 (Bit_Chain *restrict dat, Dwg_Object *restrict obj)
               SUB_FIELD_CMTC (rowstyles[i].borders[j], color, 0);
             }
         FREE_IF (_obj->rowstyles[i].borders);
-        SUB_FIELD_HANDLE (rowstyles[i], text_style, 5, 7);
-        SUB_FIELD_CMTC (rowstyles[i], text_color, 0);
-        SUB_FIELD_CMTC (rowstyles[i], fill_color, 0);
+        // text_style, text_color and fill_color are shallow copies of the
+        // cellstyle content_format/bg_color made by downconvert_TABLESTYLE.
+        // They are owned and freed via the spec free below, so freeing them
+        // here would double-free them.
       }
   FREE_IF (_obj->rowstyles);
   _obj->num_rowstyles = 0;


### PR DESCRIPTION
ASan, decoding an r2010+ DWG with a TABLESTYLE and re-encoding it down to <= r2007:

    heap-use-after-free READ in dwg_free_TABLESTYLE_private dwg2.spec:990
      freed by      free_TABLESTYLE_r2010 free.c:645
      allocated by  dwg_decode_handleref_with_code decode.c:4752

    attempting double-free in free_TABLESTYLE_r2010
      free.c:665  ovr.cellstyle.bg_color
      free.c:647  rowstyles[0].fill_color   (same pointer)

downconvert_TABLESTYLE shallow-copies the r2010+ cellstyle text_style handle and the content_color/bg_color name strings into rowstyles[0]. free_TABLESTYLE_r2010 then freed those aliases, but the spec free (CellStyle_fields / bg_color) already owns and releases the originals, so each is freed twice. Dropping the three alias frees fixes it; the owned rowstyles and borders arrays are still freed.
