### PR TITLE
Make R2004+ decompression size cap configurable

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -72,6 +72,32 @@ static bool env_var_checked_p;
 // #undef LOG_POS
 // #define LOG_POS LOG_INSANE (" @%" PRIuSIZE ".%u\n", dat->byte, dat->bit);
 
+#define DEFAULT_MAX_R2004_DECOMP_SIZE 0x2f000000U
+
+static bool max_decomp_size_checked_p;
+static uint32_t max_r2004_decomp_size = DEFAULT_MAX_R2004_DECOMP_SIZE;
+
+static uint32_t
+get_max_r2004_decomp_size (void)
+{
+  if (!max_decomp_size_checked_p)
+    {
+      char *probe = getenv ("LIBREDWG_MAX_DECOMP_SIZE");
+      if (probe && probe[0])
+        {
+          char *endptr = NULL;
+          unsigned long value = strtoul (probe, &endptr, 0);
+          if (endptr != probe && endptr && *endptr == '\0' && value > 0
+              && value <= UINT32_MAX)
+            max_r2004_decomp_size = (uint32_t)value;
+          else
+            LOG_WARN ("Ignore invalid LIBREDWG_MAX_DECOMP_SIZE=%s", probe);
+        }
+      max_decomp_size_checked_p = true;
+    }
+  return max_r2004_decomp_size;
+}
+
 /*------------------------------------------------------------------------------
  * Private functions
  */
@@ -1685,9 +1711,10 @@ read_R2004_section_info (Bit_Chain *restrict dat, Dwg_Data *restrict dwg,
   Bit_Chain dec = { 0 };
   BITCODE_BL i, j;
   int error;
+  const uint32_t max_decomp_size = get_max_r2004_decomp_size ();
 
-  if (decomp_data_size > 0x2f000000 && // 790Mb
-      (decomp_data_size > 8 * comp_data_size || comp_data_size > dat->size))
+  if (decomp_data_size > max_decomp_size
+      && (decomp_data_size > 8 * comp_data_size || comp_data_size > dat->size))
     {
       LOG_ERROR ("Invalid r2004_header.decomp_data_size %" PRIu32,
                  decomp_data_size);
@@ -2054,7 +2081,8 @@ read_2004_compressed_section (Bit_Chain *dat, Dwg_Data *restrict dwg,
       return DWG_ERR_VALUEOUTOFBOUNDS;
     }
   max_decomp_size = info->num_sections * info->max_decomp_size;
-  if (max_decomp_size == 0 || max_decomp_size > 0x2f000000) // 790Mb
+  if (max_decomp_size == 0
+      || max_decomp_size > get_max_r2004_decomp_size ())
     {
       LOG_ERROR ("Invalid section %s count or max decompression size. "
                  "Sections: " FORMAT_RL ", Max size: " FORMAT_RL,


### PR DESCRIPTION
## Summary

This keeps the current R2004+ maximum decompression size guard unchanged by default, but allows operators to override it explicitly with an environment variable when processing unusually large DWG files.

The new variable is:

```sh
LIBREDWG_MAX_DECOMP_SIZE=0x7fffffff
```

The value is parsed with base auto-detection, so decimal values and `0x...` hexadecimal values are both accepted. Invalid values are ignored and the default remains in effect.

## Motivation

Downstream conversion services may encounter valid DWG files whose compressed `AcDb:AcDbObjects` section expands beyond the current hard-coded `0x2f000000` cap. In that case LibreDWG fails before callers can recover at the entity level.

This PR does not raise the default cap globally. It only makes the existing safety limit configurable for deployments that intentionally opt into a higher memory ceiling.

## Default behavior

- Default remains `0x2f000000`.
- If `LIBREDWG_MAX_DECOMP_SIZE` is unset, behavior should be unchanged.
- If the variable is invalid, LibreDWG logs a warning and keeps the default.

Closes #1305.