### PR TITLE
clamp negative num_hdl in 2ndheader before writing hdl vector

### DIFF
--- a/src/2ndheader.spec
+++ b/src/2ndheader.spec
@@ -65,7 +65,19 @@ VERSIONS (R_13, R_2000) {
   VALUEOUTOFBOUNDS (num_handles, 14);
   REPEAT_F (num_handles, 14, handles, Dwg_SecondHeader_Handles)
   REPEAT_BLOCK
+      ENCODER {
+        // signed field, but used as unsigned vector count for hdl[8]:
+        // never write a negative count
+        if (_obj->handles[rcount1].num_hdl < 0)
+          _obj->handles[rcount1].num_hdl = 0;
+      }
       SUB_FIELD_RCd (handles[rcount1], num_hdl, 0); // max 8, the size
+      DECODER {
+        // clamp a negative count from a corrupt file before any writer
+        // uses it as unsigned vector count for hdl[8]
+        if (_obj->handles[rcount1].num_hdl < 0)
+          _obj->handles[rcount1].num_hdl = 0;
+      }
       SUB_VALUEOUTOFBOUNDS (handles[rcount1], num_hdl, 8);
       SUB_FIELD_RCd (handles[rcount1], nr, 0);
       SUB_VALUEOUTOFBOUNDS (handles[rcount1], nr, 13);


### PR DESCRIPTION
The SecondHeader keeps a per-slot handle backup in a fixed hdl[8] array, with num_hdl holding how many bytes are valid. num_hdl is a signed BITCODE_RCd, and while the decoder and encoder both loop with a num_hdl > 0 guard, the JSON writer goes through the default SUB_FIELD_VECTOR_N which casts the count to BITCODE_BL. A byte >= 0x80 read as int8_t becomes negative, and that cast turns it into a huge count, so json_section_2ndheader walks far past hdl[8]. The existing SUB_VALUEOUTOFBOUNDS next to it only rejects values above 8, never negatives, so nothing catches it. I hit this feeding a crafted R13-R2000 file through decode then --format JSON: UBSan reports index 8 out of bounds for BITCODE_RC[8]. Clamping a negative num_hdl to 0 right after it is read in the shared spec closes the read for every consumer while leaving valid 0..8 counts untouched.