### PR TITLE
dxf: hex-encode binary TF chunks (group codes 310-319)

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -5525,7 +5525,7 @@ DWG_ENTITY (OLE2FRAME)
 #ifdef IS_DXF
   // via dwg_decode_ole2() from the first 0x80 bytes in data
   FIELD_BS (oleversion, 70); //  always 2
-  FIELD_TF (oleclient, strlen (_obj->oleclient), 3);
+  FIELD_TF (oleclient, strlen ((char *)_obj->oleclient), 3);
   FIELD_3BD (pt1, 10);  // upper left
   FIELD_3BD (pt2, 11);  // lower right
 #endif

--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -678,7 +678,19 @@ dxf_print_rd (Bit_Chain *dat, BITCODE_RD value, int dxf)
 #define FIELD_RLL(nam, dxf) FIELDG (nam, RLL, dxf)
 #define FIELD_MC(nam, dxf) FIELDG (nam, MC, dxf)
 #define FIELD_MS(nam, dxf) FIELDG (nam, MS, dxf)
-#define FIELD_TF(nam, len, dxf) VALUE_TV (_obj->nam, dxf)
+/* Group codes 310-319 hold binary chunks: hex-encode them. Writing them
+   through the string path (VALUE_TV) emits the raw bytes (and applies the
+   r2007+ codepage conversion to them), producing invalid DXF that readers
+   reject, e.g. PROXY_ENTITY.proxy_data. */
+#define FIELD_TF(nam, len, dxf)                                               \
+  {                                                                           \
+    if ((dxf) >= 310 && (dxf) <= 319)                                         \
+      {                                                                       \
+        VALUE_BINARY (_obj->nam, len, dxf)                                    \
+      }                                                                       \
+    else                                                                      \
+      VALUE_TV (_obj->nam, dxf)                                               \
+  }
 #define FIELD_TFF(nam, len, dxf) VALUE_TV (_obj->nam, dxf)
 #define FIELD_TV(nam, dxf)                                                    \
   if (dxf)                                                                    \


### PR DESCRIPTION
## Problem

`FIELD_TF` in the DXF writer routes every field through the string path (`VALUE_TV`). For fields whose DXF group code is a **binary chunk** (310–319) — currently `PROXY_ENTITY.proxy_data` — this emits the raw bytes verbatim into the DXF (and even applies the r2007+ codepage conversion to them), instead of the hex encoding the DXF spec requires for those groups. The resulting file is invalid and readers reject it (ezdxf: `DXFStructureError: Invalid binary data`).

## Reproducer

A real-world 27 MB r2013 cadastre drawing (AcDs segments, partially decoded `ACAD_PROXY_ENTITY`s — the same class of file as oss-fuzz 530762732). Before af67061c, `dwg2dxf` segfaulted on it; with that fix applied the conversion completes, but the output is still rejected by every DXF reader we tried because of the raw `proxy_data` bytes:

```
310
QM-%^YFM-^@        <- raw bytes where hex pairs belong
```

I can share the sample privately if useful (it contains third-party project data).

## Fix

Route group codes 310–319 through `VALUE_BINARY` (the existing hex writer, already NULL-safe and 127-byte chunked). The previously discarded `len` macro argument now compiles, which exposed a `-Werror=pointer-sign` in OLE2FRAME's `strlen` call — cast added.

## Testing

`make check` on 0.14 + this patch: **all 254 unit tests pass** (built with `-Wno-error` to sidestep the pre-existing `add_test.c` const-qualifier warnings under GCC 15, unrelated to this change). The cadastre reproducer converts cleanly and the output loads in ezdxf with 92k modelspace entities.

Found while building [IngeCAD](https://github.com/tuxiasumari/ingecad), a free 2D CAD for Linux that embeds LibreDWG as its DWG converter.

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>