### PR TITLE
in_dxf: reset hdl_idx per HATCH path — associative hatches lost their pattern

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -3675,6 +3675,12 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
               next_330_boundary_handles = true;
               o->paths[j].num_boundary_handles = pair->value.l;
               // o->num_boundary_handles += pair->value.l;
+              // each path carries its own handle list; without this reset
+              // the 330s of every path after the first were rejected,
+              // leaving num_boundary_handles set with a NULL array - which
+              // the encoder then turns into a short handle stream,
+              // corrupting the rest of the HATCH (pattern lost)
+              hdl_idx = -1;
               LOG_TRACE (
                   "HATCH.paths[%d].num_boundary_handles = %ld [BL 97]\n", j,
                   pair->value.l);
@@ -3708,6 +3714,7 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
           o->paths[j].num_boundary_handles = pair->value.l;
           next_330_boundary_handles = true;
           // o->num_boundary_handles += pair->value.l;
+          hdl_idx = -1; // see the non-polyline 97 handler above
           LOG_TRACE (
               "HATCH.paths[%d].num_boundary_handles = %ld [BL 97] (1)\n", j,
               pair->value.l);


### PR DESCRIPTION
Associative HATCHes with more than one boundary path lose their pattern definition (scale zeroed, no def lines) through a DXF→DWG→DXF roundtrip.

## Cause

Each boundary path carries its own `97` handle-count followed by its `330` handles, but `add_HATCH`'s `hdl_idx` is never reset when a new `97` arrives. The 330s of every path after the first fail the `(hdl_idx + 1) < num_boundary_handles` guard and are rejected (`Unknown DXF code 330 for HATCH`), leaving `num_boundary_handles` set with a NULL `boundary_handles` array. The encoder then emits a short handle stream (`Invalid boundary_handles size 1. Need min. 8 bits, have 3`), corrupting the rest of the entity — decoded back, the hatch has `pattern_scale 0` and no definition lines.

## Reproducer (minimized)

An associative ring: two edge paths (full-circle arcs), each with one source boundary handle, ANSI31 scale 2.5. `dxf2dwg --as r2000` + `dwg2dxf`:

- before: `pattern ANSI31, scale 0.0, 0 pattern lines`
- after: identical roundtrip.

Found on a real pavement plan where exactly the two multi-path associative hatches (of 57) came back destroyed; with the fix all 57 roundtrip with zero differences.

## Testing

All 254 unit tests pass on 0.14 + this fix. Sibling PRs from the same real-file hunt: #1311, #1312.

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>