### PR TITLE
dxf: sanitize partially decoded values — zero handles, MTEXT columns

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -2944,6 +2944,10 @@ DWG_ENTITY (MTEXT)
         FIELD_BD (extents_height, 43);
         // end redundant fields
 
+        // Partial decodes leave garbage here (256, 35141...); a 71 value
+        // > 2 crashes DXF readers (ezdxf ColumnType) — treat as "no columns"
+        if (FIELD_VALUE (column_type) > 2)
+          FIELD_VALUE (column_type) = 0;
         FIELD_BS (column_type, 71);
         if (FIELD_VALUE (column_type))
           {

--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -1116,7 +1116,11 @@ static int dwg_dxf_TABLECONTENT (Bit_Chain *restrict dat,
     if (obj->handle.value)                                                    \
       LOG_TRACE ("handle: " FORMAT_H "\n", ARGS_H (obj->handle));             \
     if (dat->version > R_11 || dwg->header_vars.HANDLING)                     \
-      fprintf (dat->fh, "%3i\r\n" FMT_H "\r\n", 5, obj->handle.value);        \
+      {                                                                       \
+        if (!obj->handle.value)                                               \
+          dxf_fixup_zero_handle (obj);                                        \
+        fprintf (dat->fh, "%3i\r\n" FMT_H "\r\n", 5, obj->handle.value);      \
+      }                                                                       \
     error |= dxf_common_entity_handle_data (dat, obj);                        \
     error |= dwg_dxf_##token##_private (dat, hdl_dat, str_dat, obj);          \
     error |= dxf_write_eed (dat, obj->tio.object);                            \
@@ -1174,6 +1178,8 @@ static int dwg_dxf_TABLECONTENT (Bit_Chain *restrict dat,
         {                                                                     \
           BITCODE_BL vcount;                                                  \
           const int dxf = obj->type == DWG_TYPE_DIMSTYLE ? 105 : 5;           \
+          if (!obj->handle.value)                                             \
+            dxf_fixup_zero_handle (obj);                                      \
           VALUE_H (obj->handle.value, dxf);                                   \
           _XDICOBJHANDLE (3);                                                 \
           _REACTORS (4);                                                      \
@@ -1382,6 +1388,22 @@ cquote (char *restrict dest, const size_t len, const char *restrict src)
      \M+xxxxx => \U+XXXX (shift-jis)
    split by intermediate UCS-2, convert all unicode to \\U+
  */
+/* Objects can arrive from partial decodes with handle 0, which readers
+   reject outright ("Invalid handle 0"), killing the whole file. Assign a
+   fresh unique handle at write time instead. */
+static BITCODE_RLL
+dxf_fixup_zero_handle (const Dwg_Object *restrict obj)
+{
+  static BITCODE_RLL last = 0;
+  Dwg_Object *o = (Dwg_Object *)obj;
+  BITCODE_RLL next = dwg_next_handle (obj->parent);
+  if (next <= last)
+    next = last + 1;
+  last = next;
+  o->handle.value = next;
+  return next;
+}
+
 static void
 dxf_fixup_string (Bit_Chain *restrict dat, char *restrict str, const int opts,
                   const int dxf)
@@ -3732,6 +3754,9 @@ dxf_ENDBLK_empty (Bit_Chain *restrict dat, const Dwg_Object *restrict hdr)
   // Dwg_Entity_ENDBLK *_obj;
   obj->parent = dwg;
   obj->index = dwg->num_objects;
+  // a real handle: readers reject the 0 that calloc leaves ("Invalid
+  // handle 0"), killing the whole file for the sake of a filler ENDBLK
+  obj->handle.value = dwg_next_handle (dwg);
   dwg_setup_ENDBLK (obj);
   obj->tio.entity->ownerhandle
       = (BITCODE_H)calloc (1, sizeof (Dwg_Object_Ref));


### PR DESCRIPTION
Two more findings from sweeping a 1,385-file real-world DWG corpus, both of the form "partial decode leaves garbage that makes the emitted DXF fatally invalid":

## 1. Objects written with handle 0
Partially decoded objects (LAYOUTs in the wild, plus the synthetic ENDBLK from `dxf_ENDBLK_empty`) get written as `5/0`. Readers reject handle 0 outright (ezdxf: `ValueError: Invalid handle 0`), losing the whole file over a filler object. `dxf_fixup_zero_handle` assigns a fresh unique handle at write time (monotonic on top of `dwg_next_handle`).

## 2. MTEXT embedded-object column garbage
Partial decodes leave `column_type` uninitialized (values like 256, 8908, 35141 seen across 6 files, with `column_width` at 1.3e+218). A 71 group > 2 crashes ezdxf's `ColumnType` enum and corrupts other readers' column parsing. Out-of-range values are now treated as "no columns" — the column block is skipped.

## Results
Fixed 7 of the corpus' remaining unreadable conversions (6× ColumnType, 1× handle 0). All 254 unit tests pass on 0.14 + the full patch series (this one applies independently of #1314).

Also observed, for the record (deeper decode-side issues, happy to share samples privately): files whose entities decode with massively duplicated low handles (#1..#2A), r2018 files where most objects come out as UNKNOWN_OBJ/UNKNOWN_ENT (Civil 3D proxies), and AC1009 (r11) files failing at `DWG_SENTINEL_R11_LAYER_BEGIN`.

Sibling PRs: #1311 #1312 #1313 #1314. From [IngeCAD](https://github.com/tuxiasumari/ingecad)'s corpus harness (`tools/dwg_bench.py`).

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>