### PR TITLE
dxf import: fix two quadratic slowdowns (memBEGINc strlen, dead ordered-ref index)

### DIFF
--- a/src/dwg.c
+++ b/src/dwg.c
@@ -4054,11 +4054,13 @@ ordered_ref_add (Dwg_Data *dwg, Dwg_Object_Ref *ref)
     }
   else
     {
-      // There are duplicates, disable bsearch
-      // It should never happen !
-      free (dwg->object_ordered_ref);
-      dwg->object_ordered_ref = NULL;
-      dwg->num_object_ordered_refs = -1;
+      // Duplicate (code, absref) pair. This DOES happen: dwg_add_handleref
+      // only dedupes via ordered_ref_find on some paths (e.g. obj == NULL),
+      // yet always calls ordered_ref_add. Disabling the index here demoted
+      // every later lookup to a linear scan over all refs — quadratic DXF
+      // import (minutes for a 19 MB file). Refs with the same key are
+      // interchangeable by design (the dedupe branch returns any of them),
+      // so just skip the duplicate and keep the index alive.
     }
 }
 

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -658,7 +658,11 @@ dxf_read_string (Bit_Chain *dat, char **string)
            dat->byte++)
         {
           char *s = (char *)&dat->chain[dat->byte];
-          if (memBEGINc (s, "\\M+") && s[3] >= '1' && s[3] <= '5')
+          // Compare the 3 bytes directly: memBEGINc would strlen() the whole
+          // remaining multi-MB buffer for EVERY character of EVERY string,
+          // making DXF import quadratic in file size (a 19 MB DXF "hangs").
+          if (dat->byte + 3 < dat->size && s[0] == '\\' && s[1] == 'M'
+              && s[2] == '+' && s[3] >= '1' && s[3] <= '5')
             {
               const Dwg_Codepage mif_tbl[]
                   = { CP_UNDEFINED, CP_ANSI_932,  CP_ANSI_950,


### PR DESCRIPTION
Two independent perf bugs made big DXF imports quadratic; together they took a real 19 MB DXF from **>5 minutes (appears hung) to 1.8 s**.

1. **`dxf_read_string` called `memBEGINc (s, "\\M+")` per character**, and `memBEGINc` does `strlen(s1)` — here `s` points into the raw file buffer, so every character of every string value scanned the entire remaining file: O(file_size²). Compare the 3 bytes directly.

2. **A duplicate `(code, absref)` handleref permanently disabled the ordered-ref bsearch index.** `dwg_add_handleref` only dedupes via `ordered_ref_find` on some paths (e.g. `obj == NULL`) yet always calls `ordered_ref_add`, so duplicates DO happen on real files; the "should never happen" branch freed the index and demoted every later lookup to a linear scan over all refs. Refs with the same key are interchangeable by design (the dedupe branch returns any of them), so skip the duplicate and keep the index alive.

Found with the same real-file corpus as #1311–#1315 (1,385 DWGs). The full LibreDWG unit-test suite (254 tests) passes with these fixes on 0.14; the port to master is line-identical and compile-checked (this environment lacks autotools for a full `make check` on master — happy to iterate if CI flags anything).