### PR TITLE
HATCH: three spline-edge/path bugs that corrupt or drop hatch data

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -4743,9 +4743,17 @@ DWG_ENTITY (HATCH)
                         {
 #define seg segx[rcount2]
                           SUB_FIELD_BL (seg, num_fitpts, 97);
-                          FIELD_2RD_VECTOR (seg.fitpts, seg.num_fitpts, 11);
-                          SUB_FIELD_2RD (seg, start_tangent, 12);
-                          SUB_FIELD_2RD (seg, end_tangent, 13);
+                          // AutoCAD writes the fit points and the two
+                          // tangents only when the spline edge was defined by
+                          // fit points (num_fitpts > 0). Reading the tangents
+                          // unconditionally overran the object and dropped the
+                          // remaining hatch edges/paths.
+                          if (FIELD_VALUE (seg.num_fitpts))
+                            {
+                              FIELD_2RD_VECTOR (seg.fitpts, seg.num_fitpts, 11);
+                              SUB_FIELD_2RD (seg, start_tangent, 12);
+                              SUB_FIELD_2RD (seg, end_tangent, 13);
+                            }
                         }
                       break;
                     default:

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -3156,7 +3156,11 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
           o->paths[j].flag = pair->value.u;
           LOG_TRACE ("HATCH.paths[%d].flag = %u [BL 92]\n", j, pair->value.u);
           is_plpath = pair->value.u & 2;
-          o->has_derived = pair->value.u & 4;
+          // has_derived is the OR of every path flag's 0x4 bit (the decoder
+          // computes it that way); a plain '=' left it holding only the last
+          // path's bit, so the encoder skipped pixel_size while the reader
+          // expected it -> misaligned num_seeds and an unreadable HATCH.
+          o->has_derived |= (pair->value.u & 4) ? 1 : 0;
           LOG_TRACE ("HATCH.has_derived = %d [B 0]\n", o->has_derived);
         }
       else if (pair->code == 93)

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -3080,6 +3080,7 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   int j = -1;
   int k = -1;
   int l = -1;
+  int knots_left = 0; // spline knots pending; they precede rational weights
   int hdl_idx = -1;
   bool next_330_boundary_handles = false;
 
@@ -3261,6 +3262,7 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
           CHK_paths;
           CHK_segs;
           o->paths[j].segs[k].num_knots = pair->value.l;
+          knots_left = (int)pair->value.l;
           LOG_TRACE ("HATCH.paths[%d].segs[%d].num_knots = %ld [BL 95]\n", j,
                      k, pair->value.l);
           o->paths[j].segs[k].knots
@@ -3537,7 +3539,13 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
                   j, k, pair->value.d);
               break;
             case 4: /* SPLINE */
-              if (l >= 0 && o->paths[j].segs[k].is_rational)
+              // A rational spline stores its knots (num_knots of them) BEFORE
+              // the per-control-point weights, and both use DXF code 40. While
+              // knots remain, code 40 is a knot even when is_rational is set;
+              // keying only on is_rational sent every knot after the first to
+              // the weight branch, corrupting the knots and overrunning the
+              // control-point array ("wrong l N control_points index").
+              if (knots_left <= 0 && l >= 0 && o->paths[j].segs[k].is_rational)
                 {
                   CHK_control_points;
                   o->paths[j].segs[k].control_points[l].weight = pair->value.d;
@@ -3563,6 +3571,7 @@ add_HATCH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
                   l++;
                   CHK_knots;
                   o->paths[j].segs[k].knots[l] = pair->value.d;
+                  knots_left--;
                   LOG_TRACE (
                       "HATCH.paths[%d].segs[%d].knots[%d] = %f [BD 40]\n", j,
                       k, l, pair->value.d);


### PR DESCRIPTION
Three HATCH bugs, all exposed by complex real-world hatches (pavement/plaza detail sheets) through the `dwg2dxf → dxf2dwg` r2000 round trip; each alone produces an unreadable hatch ("Object improperly read: <AcDbHatch>") or silently drops data:

- **dwg.spec (decoder, R2010+ spline edges): fit points/tangents must be read only when `num_fitpts > 0`.** AutoCAD writes the two tangents only for fit-point-defined spline edges; reading them unconditionally overran the object and the decoder silently dropped every remaining edge/path of the hatch, so `dwg2dxf` emitted counts that disagreed with the data (a 3-path/6-edge hatch came out as 2/3).
- **`in_dxf`: `has_derived` must OR every path flag's 0x4 bit** (that is how the decoder computes it); plain `=` kept only the last path's bit, so the encoder skipped `pixel_size` while the reader expected it → misaligned `num_seeds`.
- **`in_dxf`: a rational spline's knots were read as weights.** Knots (code 40, `num_knots` of them) precede the per-control-point weights (also code 40); keying only on `is_rational` sent every knot after the first to the weight branch, corrupting knots and overrunning the control-point array ("wrong l N control_points index", aborting the import with READ ERROR). Track the pending-knot count.

With these three, two previously-fatal real files (both fail on master) convert clean and open in BricsCAD/ODA. 254 unit tests green on 0.14; master port line-identical, compile-checked.