### PR TITLE
bits: r2000 TV length excludes the trailing NUL; fix bit_write_DD mode selection

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -1300,15 +1300,23 @@ bit_write_DD (Bit_Chain *dat, double value, double default_value)
       const unsigned char *uchar_value = (const unsigned char *)&value;
       const unsigned char *uchar_default
           = (const unsigned char *)&default_value;
-      const uint16_t *uint_value = (const uint16_t *)&uchar_value;
-      const uint16_t *uint_default = (const uint16_t *)&uchar_default;
-      // dbl: 7654 3210, little-endian only
-      // check the first 2 bits for eq
-      if (le16toh (uint_value[0]) == le16toh (uint_default[0]))
+      // Alias the DOUBLE bytes, not the address of the pointer variable:
+      // (const uint16_t *)&uchar_value compared two stack addresses, so the
+      // DD mode (which 4/6 bytes to emit) was chosen from garbage and
+      // partial-mode writes corrupted the value (e.g. an INSERT yscale of 1
+      // came back as the insertion-point Y). Must alias the value bytes.
+      const uint16_t *uint_value = (const uint16_t *)uchar_value;
+      const uint16_t *uint_default = (const uint16_t *)uchar_default;
+      // dbl: 7654 3210, little-endian only. bit_read_DD keeps the HIGH bytes
+      // of the default (word3 = bytes 6-7 for code 2, words 2+3 = bytes 4-7
+      // for code 1) and reads the rest, so the encoder must pick the mode by
+      // the HIGH words, not the low ones — comparing uint_value[0]/[1]
+      // mis-selected the partial modes and corrupted the value.
+      if (le16toh (uint_value[3]) == le16toh (uint_default[3]))
         {
-          // first 4 bits eq, i.e. next 2 bits also
+          // top 2 bytes eq; is the whole high half (top 4 bytes) eq too?
           // cppcheck-suppress objectIndex
-          if (le16toh (uint_value[1]) == le16toh (uint_default[1]))
+          if (le16toh (uint_value[2]) == le16toh (uint_default[2]))
             {
               bits = 1;
               bit_write_BB (dat, 1);

--- a/src/bits.c
+++ b/src/bits.c
@@ -2247,7 +2247,12 @@ bit_write_TV (Bit_Chain *restrict dat, BITCODE_TV restrict chain)
     bit_write_RS (dat, (BITCODE_RS)length);
   else
     {
-      if (dat->version >= R_14 && length)
+      // The trailing NUL in the TV length is an r2004+ convention: the
+      // reader side only ever observed zero-terminated strings from
+      // >= r2004 writer apps, and pre-r2004 lengths equal strlen (ODA's
+      // ACAD2000 output confirms: "SOLID" is written as 5, not 6). Writing
+      // the NUL into r2000 made every string one byte off AutoCAD's layout.
+      if (dat->version >= R_2004 && length)
         length++; // TV-ZERO
       bit_write_BS (dat, (BITCODE_BS)length);
     }

--- a/test/unit-testing/bits_test.c
+++ b/test/unit-testing/bits_test.c
@@ -1257,13 +1257,27 @@ bit_write_TV_tests (void)
   else
     fail ("bit_write_TV @%" PRIuSIZE ".%u", bitchain.byte, bitchain.bit);
 
+  // r2000: BS length + bytes, NO trailing-NUL in the length (ODA's ACAD2000
+  // output writes "SOLID" as 5, not 6). "GNU" -> BS(3) + 3 bytes = @4.2.
   bit_set_position (&bitchain, 0);
-  bitchain.from_version = R_13;
+  bitchain.from_version = bitchain.version = R_2000;
+  bit_write_TV (&bitchain, (char *)"GNU");
+  if (bitchain.byte == 4 && bitchain.bit == 2)
+    ok ("bit_write_TV (R_2000, no TV-ZERO)");
+  else
+    fail ("bit_write_TV R_2000 @%" PRIuSIZE ".%u", bitchain.byte,
+          bitchain.bit);
+
+  // r2004+: the length includes the trailing NUL (TV-ZERO). "GNU" -> BS(4)
+  // + 3 bytes = @5.2.
+  bit_set_position (&bitchain, 0);
+  bitchain.from_version = bitchain.version = R_2004;
   bit_write_TV (&bitchain, (char *)"GNU");
   if (bitchain.byte == 5 && bitchain.bit == 2)
-    ok ("bit_write_TV (>R_13)");
+    ok ("bit_write_TV (R_2004, TV-ZERO)");
   else
-    fail ("bit_write_TV @%" PRIuSIZE ".%u", bitchain.byte, bitchain.bit);
+    fail ("bit_write_TV R_2004 @%" PRIuSIZE ".%u", bitchain.byte,
+          bitchain.bit);
 
   bitfree (&bitchain);
 }


### PR DESCRIPTION
Two low-level encoder bugs that made LibreDWG-written r2000 DWGs unreadable or subtly corrupt for AutoCAD/BricsCAD/ODA:

- **`bit_write_TV`: the trailing NUL in the TV length is an r2004+ convention.** Pre-r2004 lengths equal `strlen` — ODA's ACAD2000 output confirms ("SOLID" is written as 5, not 6). Writing the NUL into r2000 made *every string one byte long*, shifting the object body; the first victim in a real file is typically a HATCH ("Object improperly read: <AcDbHatch>" in BricsCAD/ODA). Gate on `>= R_2004`. The reader side already tolerates both. Companion test asserts both layouts (r2000 @4.2, r2004 @5.2).
- **`bit_write_DD` aliased the pointer, not the value, and compared the wrong words.** `(const uint16_t *)&uchar_value` takes the address of the local *pointer variable*, so the DD mode (how many bytes to emit) was chosen from stack garbage; and the comparison used the LOW words while `bit_read_DD` keeps the HIGH bytes of the default (word 3 for code 2, words 2+3 for code 1). Partial-mode writes therefore corrupted values (e.g. an INSERT yscale of 1 came back as the insertion-point Y). Alias the value bytes and compare the high words so encode matches decode.

Found via bit-position diffing of `dwgread -v5` output against ODA's ACAD2000 files as a strict oracle (same corpus as #1311–#1315). With these (plus the import fixes in the sibling PRs), previously-rejected LibreDWG r2000 output opens and renders correctly in BricsCAD. 254 unit tests green on 0.14, including the new TV cases; master port line-identical, compile-checked.