### PR TITLE
in_dxf/dwg: handle & ownership fixes so conformant readers accept our r2000 output

### DIFF
--- a/src/dwg.c
+++ b/src/dwg.c
@@ -3503,11 +3503,30 @@ dwg_set_next_objhandle (Dwg_Object *obj)
   BITCODE_RLL seed;
   if (dwg->next_hdl)
     {
-      obj->handle.value = dwg->next_hdl;
-      dwg_set_handle_size (&obj->handle);
-      hash_set (dwg->object_map, obj->handle.value, (uint64_t)obj->index);
+      // Only honor the requested handle if it is still free. A stale next_hdl
+      // (e.g. left over from DXF import when a table record is added later at
+      // encode time, like the "LibreDWG"/ACAD_MLEADERVER APPIDs) would
+      // otherwise collide with an existing object and produce a DWG whose
+      // handle map is ambiguous ("... TableRecord can't be cast to
+      // AcDbEntity" in AutoCAD/BricsCAD/ODA). On collision, fall through to a
+      // fresh handseed.
+      uint64_t existing = dwg->object_map
+                              ? hash_get (dwg->object_map, dwg->next_hdl)
+                              : HASH_NOT_FOUND;
+      if (existing == HASH_NOT_FOUND || existing == (uint64_t)obj->index)
+        {
+          obj->handle.value = dwg->next_hdl;
+          dwg_set_handle_size (&obj->handle);
+          if (!dwg->object_map)
+            dwg->object_map = hash_new (200);
+          hash_set (dwg->object_map, obj->handle.value, (uint64_t)obj->index);
+          dwg->next_hdl = 0;
+          return;
+        }
+      LOG_WARN ("next_hdl " FORMAT_HV " already used by object %" PRIu64
+                ", using a fresh handseed",
+                dwg->next_hdl, existing);
       dwg->next_hdl = 0;
-      return;
     }
   seed = dwg_new_handseed (dwg);
   if (!dwg->object_map)

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -14028,7 +14028,11 @@ dxf_blocks_read (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
                            || bit_eq_T (dat, _obj->name, "*PAPER_SPACE"))
                     entmode = ent->entmode = 1;
                   else
-                    entmode = ent->entmode = 3; // regular block entities
+                    // Regular block members use entmode 0 (explicit owner =
+                    // block record), matching AutoCAD/ODA. entmode 3 (model
+                    // space) makes conformant readers resolve the BlockBegin
+                    // owner to *Model_Space -> "BlockBegin owner Id invalid".
+                    entmode = ent->entmode = 0; // regular block entities
                   if (!ent->isbylayerlt && !ent->ltype_flags && !ent->ltype)
                     ent->isbylayerlt = 1;
                 }

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -10219,8 +10219,12 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
                     = obj->tio.object->tio.SORTENTSTABLE;
                 if (o->num_ents > 0 && !o->sort_ents[o->num_ents - 1])
                   {
+                    // sort_ents are code-0 ordering handles that alias real
+                    // entity handles; pass NULL so they are NOT registered in
+                    // the object_map (obj would collide with the true entity,
+                    // corrupting handle resolution on large files).
                     BITCODE_H hdl
-                        = dwg_add_handleref (dwg, 0, pair->value.u, obj);
+                        = dwg_add_handleref (dwg, 0, pair->value.u, NULL);
                     o->sort_ents[o->num_ents - 1] = hdl;
                     LOG_TRACE ("SORTENTSTABLE.sort_ents[%d] = " FORMAT_REF
                                " [H 5]\n",

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -13901,6 +13901,19 @@ dxf_blocks_read (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
                           _hdr->base_pt.x = _obj->base_pt.x;
                           _hdr->base_pt.y = _obj->base_pt.y;
                           LOG_TRACE ("BLOCK_HEADER.base_pt = BLOCK.base_pt\n");
+                          // A bound/local block (e.g. "A$C..." from a bound
+                          // xref) keeps a stray xref bit in its BLOCK_RECORD
+                          // flag 70, but a real xref must have an xref path.
+                          // No path => it is local: clear blkisxref, or
+                          // AutoCAD/BricsCAD render it as an unresolved Xref.
+                          if (_hdr->blkisxref
+                              && bit_empty_T (dat, _obj->xref_pname))
+                            {
+                              _hdr->blkisxref = 0;
+                              _hdr->xrefoverlaid = 0;
+                              LOG_TRACE ("BLOCK_HEADER.blkisxref = 0 "
+                                         "(no xref path, local block)\n");
+                            }
                         }
                       else if (blkhdr->fixedtype == DWG_TYPE_BLOCK_CONTROL)
                         {

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -9497,6 +9497,38 @@ dxf_postprocess_PLOTSETTINGS (Dwg_Object *restrict obj)
     _obj->plotview_name = dwg_handle_name (dwg, "VIEW", _obj->plotview);
 }
 
+static void
+dxf_postprocess_SORTENTSTABLE (Dwg_Object *restrict obj)
+{
+  Dwg_Data *dwg = obj->parent;
+  Dwg_Object_Object *_o = obj->tio.object;
+  Dwg_Object_SORTENTSTABLE *_obj = _o->tio.SORTENTSTABLE;
+  Dwg_Object *dict;
+
+  // block_owner must be the BLOCK_HEADER whose entities this table sorts,
+  // i.e. the owner of the extension dictionary that owns the table. An empty
+  // table carries no explicit block_owner in DXF, and the importer misread
+  // the object owner (the dictionary) as block_owner -> AutoCAD/ODA reject
+  // the owning block ("Invalid input <AcDbBlockTableRecord>", BlockEnd needs
+  // recovery). A non-empty table's block_owner differs from its owner and is
+  // trusted as-is.
+  if (!_o->ownerhandle)
+    return;
+  if (_obj->block_owner
+      && _obj->block_owner->absolute_ref != _o->ownerhandle->absolute_ref)
+    return;
+  dict = dwg_ref_object (dwg, _o->ownerhandle);
+  if (dict && dict->supertype == DWG_SUPERTYPE_OBJECT
+      && dict->tio.object->ownerhandle
+      && dict->tio.object->ownerhandle->absolute_ref)
+    {
+      _obj->block_owner = dwg_add_handleref (
+          dwg, 4, dict->tio.object->ownerhandle->absolute_ref, NULL);
+      LOG_TRACE ("SORTENTSTABLE.block_owner = " FORMAT_REF " (fixup)\n",
+                 ARGS_REF (_obj->block_owner));
+    }
+}
+
 // separate model_space and paper_space into its own fields, out of entries[]
 static int
 move_out_BLOCK_CONTROL (Dwg_Object *restrict obj,
@@ -13472,6 +13504,8 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
     dxf_postprocess_MLINESTYLE (obj); // FIXME. not triggered
   else if (obj->fixedtype == DWG_TYPE_PLOTSETTINGS)
     dxf_postprocess_PLOTSETTINGS (obj);
+  else if (obj->fixedtype == DWG_TYPE_SORTENTSTABLE)
+    dxf_postprocess_SORTENTSTABLE (obj);
   // set defaults not in dxf:
   else if (obj->type == DWG_TYPE__3DFACE && dwg->header.from_version >= R_2000)
     {


### PR DESCRIPTION
Five ownership/handle-semantics bugs. Each one makes AutoCAD/BricsCAD/ODA warn on or reject a DWG written from imported DXF; together they were the difference between "opens with recovery errors" and "opens clean" for a 92k-entity cadastre:

- **SORTENTSTABLE sort handles must not register in `object_map`.** sort_ents are code-0 *ordering* handles that intentionally alias real entity handles; passing `obj` to `dwg_add_handleref` registered each one in the object map, colliding with the true entity (a real cadastre emitted 3,040 "Duplicate handle" errors) and corrupting handle resolution → invalid block owners downstream. Pass NULL.
- **`SORTENTSTABLE.block_owner` was the extension DICTIONARY, not the BLOCK_HEADER.** An empty block-scoped table has no explicit 330 for it in DXF and the importer misread the object owner. Derive it from the ownership chain (owner of the owning dictionary); non-empty tables with a distinct explicit block_owner are trusted as-is.
- **Regular block members were imported with entmode 3** (model space, no owner in stream). AutoCAD/ODA write entmode 0 (explicit owner = block record) for block members — with 3, conformant readers resolve the BlockBegin owner to *Model_Space and warn "BlockBegin owner Id is invalid" on every block.
- **A bound/local block (e.g. `A$C…`) kept a stray xref bit** in BLOCK_RECORD flag 70; with no xref path it must be local, or readers render whole layers as unresolved "Xref" placeholders.
- **`dwg_set_next_objhandle` honored a stale `next_hdl` without checking `object_map`.** When a table record is added at encode time after DXF import (the "LibreDWG"/ACAD_MLEADERVER APPIDs), it could land on a handle already owned by e.g. an LTYPE → ambiguous handle map → "AcDbRegAppTableRecord can't be cast to AcDbEntity". Reuse the requested handle only if free, else fall through to a fresh handseed.

Verified field-by-field against ODA's ACAD2000 output (entmode distribution, owner warnings 10→0 / 45→0 on the bench files) and visually in BricsCAD. 254 unit tests green on 0.14; master port line-identical, compile-checked.