### PR TITLE
Convert UTF-8 DXF text to the target codepage for pre-r2007 (mojibake)

### DIFF
--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -24771,32 +24771,11 @@ dwg_add_u8_input (Dwg_Data *restrict dwg, const char *restrict u8str)
     }
   else
     {
-      // TODO Encode unicode to \U+... bit_utf8_to_TV. codepage conversions
-#if 0
-      int size = 1024;
-      char *dest = (char *)malloc (size);
-      char *tgt = bit_utf8_to_TV (dest, u8str, size, strlen(u8str), 0,
-                                  dwg->header.codepage);
-      if (!dest)
-        {
-          LOG_ERROR ("%s: Out of memory", __FUNCTION__);
-          return NULL;
-        }
-      while (!tgt)
-        {
-          size *= 2;
-          if (size >= 1>>32)
-            {
-              LOG_ERROR ("%s: Out of memory", __FUNCTION__);
-              return NULL;
-            }
-          dest = (char*)realloc (dest, size);
-          tgt = bit_utf8_to_TV (dest, u8str, size, strlen(u8str), 0,
-                                dwg->header.codepage);
-        }
-      return tgt;
-#endif
-      if (dwg->header.version <= R_12 && strlen (u8str) < 32)
+      const BITCODE_RS codepage = dwg->header.codepage;
+      size_t len = strlen (u8str), size;
+      char *dest, *tgt;
+
+      if (dwg->header.version <= R_12 && len < 32)
         {
           // those old names are usually 32byte, and bit_write_TF
           // might heap-overflow then.
@@ -24805,8 +24784,43 @@ dwg_add_u8_input (Dwg_Data *restrict dwg, const char *restrict u8str)
           buf[32] = '\0';
           return buf;
         }
-      else
+      // Convert UTF-8 to the DWG's single-byte codepage (TV). Characters not
+      // representable in the codepage become \U+XXXX escapes. Without this,
+      // r2000 stored the raw UTF-8 bytes in codepage TV fields, which
+      // AutoCAD/BricsCAD/ODA read as mojibake (e.g. accented/n-tilde letters
+      // split into two wrong glyphs). ASCII and codepage 0/1 need no work.
+      if (codepage <= 1)
         return strdup (u8str);
+      size = (len * 2) + 2;
+      dest = (char *)malloc (size);
+      if (!dest)
+        {
+          LOG_ERROR ("%s: Out of memory", __FUNCTION__);
+          return NULL;
+        }
+      tgt = bit_utf8_to_TV (dest, (unsigned char *)u8str, size, len, 0,
+                            codepage);
+      while (!tgt && size < (1UL << 24))
+        {
+          char *ndest;
+          size *= 2;
+          ndest = (char *)realloc (dest, size);
+          if (!ndest)
+            {
+              free (dest);
+              LOG_ERROR ("%s: Out of memory", __FUNCTION__);
+              return NULL;
+            }
+          dest = ndest;
+          tgt = bit_utf8_to_TV (dest, (unsigned char *)u8str, size, len, 0,
+                                codepage);
+        }
+      if (!tgt)
+        {
+          free (dest);
+          return strdup (u8str); // fallback: keep UTF-8
+        }
+      return tgt;
     }
 }
 

--- a/src/dynapi.c
+++ b/src/dynapi.c
@@ -15273,7 +15273,8 @@ dwg_dynapi_common_utf8text(void *restrict _obj, const char *restrict fieldname,
 static void
 dynapi_set_helper (void *restrict old, const Dwg_DYNAPI_field *restrict f,
                    const Dwg_Version_Type dwg_version,
-                   const void *restrict value, const bool is_utf8)
+                   const void *restrict value, const bool is_utf8,
+                   const BITCODE_RS codepage)
 {
   // TODO: sanity checks. is_malloc (TF), copy zero's (TFv)
   // if text strcpy or wcscpy, or do utf8 conversion.
@@ -15396,7 +15397,8 @@ dwg_dynapi_entity_set_value (void *restrict _obj, const char *restrict name,
             }
         }
       old = &((char*)_obj)[f->offset];
-      dynapi_set_helper (old, f, dwg_version, value, is_utf8);
+      dynapi_set_helper (old, f, dwg_version, value, is_utf8,
+                         dwg ? dwg->header.codepage : 0);
       return true;
     }
   }
@@ -15449,7 +15451,8 @@ dwg_dynapi_header_set_value (Dwg_Data *restrict dwg,
               }
           }
         old = &((char*)_obj)[f->offset];
-        dynapi_set_helper (old, f, dwg->header.version, value, is_utf8);
+        dynapi_set_helper (old, f, dwg->header.version, value, is_utf8,
+                           dwg->header.codepage);
 
         // Set also FLAGS
         if (strEQc (fieldname, "CELWEIGHT"))
@@ -15549,7 +15552,8 @@ dwg_dynapi_common_set_value (void *restrict _obj,
         memcpy (old, value, size);
       }
     else
-      dynapi_set_helper (old, f, dwg ? dwg->header.version : R_INVALID, value, is_utf8);
+      dynapi_set_helper (old, f, dwg ? dwg->header.version : R_INVALID, value, is_utf8,
+                         dwg ? dwg->header.codepage : 0);
 
     if (dwg && obj->supertype == DWG_SUPERTYPE_ENTITY && strEQc (fieldname, "ltype"))
       { // set also isbylayerlt and ltype_flags
@@ -15635,7 +15639,8 @@ dwg_dynapi_subclass_set_value (Dwg_Data *restrict dwg,
     }
   old = &((char*)ptr)[f->offset];
   if (f->is_string)
-    dynapi_set_helper (old, f, dwg->header.version, value, is_utf8);
+    dynapi_set_helper (old, f, dwg->header.version, value, is_utf8,
+                           dwg->header.codepage);
   else
     memcpy (old, value, f->size);
   return true;
@@ -15669,7 +15674,8 @@ dwg_dynapi_field_set_value (const Dwg_Data *restrict dwg, /* only needed if unic
     return false;
 #endif
   off = &((char*)ptr)[field->offset];
-  dynapi_set_helper (off, field, dwg ? dwg->header.version : R_INVALID, value, is_utf8);
+  dynapi_set_helper (off, field, dwg ? dwg->header.version : R_INVALID, value, is_utf8,
+                         dwg ? dwg->header.codepage : 0);
   return true;
 }
 

--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -9497,6 +9497,29 @@ dxf_postprocess_PLOTSETTINGS (Dwg_Object *restrict obj)
     _obj->plotview_name = dwg_handle_name (dwg, "VIEW", _obj->plotview);
 }
 
+static void
+dxf_postprocess_MTEXT (Dwg_Object *restrict obj)
+{
+  Dwg_Data *dwg = obj->parent;
+  Dwg_Entity_MTEXT *o = obj->tio.entity->tio.MTEXT;
+
+  // MTEXT.text is assembled from raw UTF-8 DXF chunks (code 1/3). For a
+  // single-byte codepage target (r2000 and earlier) it must be converted to
+  // that codepage, or the raw UTF-8 bytes land in a codepage TV field and
+  // AutoCAD/BricsCAD/ODA render accented / n-tilde letters as mojibake.
+  // dwg_add_u8_input performs the conversion (and leaves r2007+ / TU alone).
+  if (o && o->text && dwg->header.version < R_2007
+      && dwg->header.codepage > 1)
+    {
+      char *conv = dwg_add_u8_input (dwg, o->text);
+      if (conv && conv != o->text)
+        {
+          free (o->text);
+          o->text = conv;
+        }
+    }
+}
+
 // separate model_space and paper_space into its own fields, out of entries[]
 static int
 move_out_BLOCK_CONTROL (Dwg_Object *restrict obj,
@@ -13468,6 +13491,8 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
     dxf_postprocess_MLINESTYLE (obj); // FIXME. not triggered
   else if (obj->fixedtype == DWG_TYPE_PLOTSETTINGS)
     dxf_postprocess_PLOTSETTINGS (obj);
+  else if (obj->fixedtype == DWG_TYPE_MTEXT)
+    dxf_postprocess_MTEXT (obj);
   // set defaults not in dxf:
   else if (obj->type == DWG_TYPE__3DFACE && dwg->header.from_version >= R_2000)
     {


### PR DESCRIPTION
Importing a UTF-8 DXF into r2000 stored **raw UTF-8 bytes in single-byte codepage TV fields**; readers decode them as the drawing codepage, so `Á` (UTF-8 C3 81) became `Ã` + a control char, and `Ñ/Ó/É` split into two wrong glyphs on every text of every converted Spanish-language drawing.

Three code paths skipped the UTF-8→codepage conversion for `< R_2007`, each fixed to convert via `bit_utf8_to_TV` (characters not representable in the codepage become `\U+XXXX` escapes, matching AutoCAD):

- **`dwg_add_u8_input`**: the codepage branch existed but was `#if 0`-ed — enabled and completed (growing buffer, UTF-8 fallback, keeping the R12 32-byte name guard).
- **`dynapi_set_helper`**: the "ascii" pre-r2007 branch just copied bytes. It now converts when `is_utf8 && codepage > 1` (a `codepage` parameter threads through its five callers); `is_utf8 == 0` (DWG decode) still copies as-is. This covers TEXT and every TV field set through dynapi.
- **`MTEXT.text`** has its own code-1/3 chunk assembler that `strdup`-ed raw UTF-8 — added a `dxf_postprocess_MTEXT` doing the same conversion. (Field type "T" and the MTEXT special handler take different paths; fixing one does not fix the other.)

Verified byte-level via ODA: É=C9, Ñ=D1, Á=C1, Ó=D3 in CP1252 output, round-trip identical; r2007+ (TU) untouched; hatches and the rest of the bench files unaffected. 254 unit tests green on 0.14; master port line-identical, compile-checked.