### PR TITLE
Fix function dwg_page_x_min to use the correct header variable.

### DIFF
--- a/src/dwg.c
+++ b/src/dwg.c
@@ -725,7 +725,7 @@ EXPORT double
 dwg_page_x_min (const Dwg_Data *dwg)
 {
   assert (dwg);
-  return dwg->header_vars.EXTMIN.x;
+  return dwg->header_vars.PEXTMIN.x;
 }
 
 EXPORT double


### PR DESCRIPTION
Current implementation of ``dwg_page_x_min`` uses variable ``EXTMIN.x`` which is accessed by ``dwg_model_x_min``.

Updated the ``dwg_page_x_min`` function to use the page version (``PEXTMIN.x``) of the variable.