### PR TITLE
Improve tests

### DIFF
--- a/test/unit-testing/bits_test.c
+++ b/test/unit-testing/bits_test.c
@@ -55,6 +55,17 @@ bit_read_BB_tests (void)
   else
     fail ("bit_read_BB %d", result);
   bitfree (&bitchain);
+
+  bitchain = strtobt ("00000001"
+                      "10000000");
+  bit_set_position (&bitchain, 7);
+  result = bit_read_BB (&bitchain);
+  if (result == 0x3 && bitchain.byte == 1 && bitchain.bit == 1)
+    pass ();
+  else
+    fail ("bit_read_BB bit=7 %d @%" PRIuSIZE ".%u", result, bitchain.byte,
+          bitchain.bit);
+  bitfree (&bitchain);
 }
 
 static void
@@ -68,6 +79,19 @@ bit_write_BB_tests (void)
     pass ();
   else
     fail ("bit_write_BB %d", bitchain.chain[0]);
+  bitfree (&bitchain);
+
+  bitchain = strtobt ("00000000"
+                      "00000000");
+  bit_set_position (&bitchain, 7);
+  bit_write_BB (&bitchain, 0x3);
+
+  if (bitchain.chain[0] == 0x01 && bitchain.chain[1] == 0x80
+      && bitchain.byte == 1 && bitchain.bit == 1)
+    pass ();
+  else
+    fail ("bit_write_BB bit=7 %02X %02X @%" PRIuSIZE ".%u", bitchain.chain[0],
+          bitchain.chain[1], bitchain.byte, bitchain.bit);
   bitfree (&bitchain);
 }
 
@@ -247,6 +271,17 @@ bit_read_RC_tests (void)
   else
     fail ("bit_read_RC");
   bitfree (&bitchain);
+
+  bitchain = strtobt ("01111111"
+                      "10000000");
+  bit_set_position (&bitchain, 1);
+  result = bit_read_RC (&bitchain);
+  if (result == 0xFF && bitchain.byte == 1 && bitchain.bit == 1)
+    pass ();
+  else
+    fail ("bit_read_RC bit=1 %02X @%" PRIuSIZE ".%u", result, bitchain.byte,
+          bitchain.bit);
+  bitfree (&bitchain);
 }
 
 static void
@@ -258,6 +293,18 @@ bit_write_RC_tests (void)
     pass ();
   else
     fail ("bit_write_RC");
+  bitfree (&bitchain);
+
+  bitchain = strtobt ("00000000"
+                      "00000000");
+  bit_set_position (&bitchain, 1);
+  bit_write_RC (&bitchain, 0xFF);
+  if (bitchain.chain[0] == 0x7F && bitchain.chain[1] == 0x80
+      && bitchain.byte == 1 && bitchain.bit == 1)
+    pass ();
+  else
+    fail ("bit_write_RC bit=1 %02X %02X @%" PRIuSIZE ".%u", bitchain.chain[0],
+          bitchain.chain[1], bitchain.byte, bitchain.bit);
   bitfree (&bitchain);
 }
 

--- a/test/unit-testing/tests_common.h
+++ b/test/unit-testing/tests_common.h
@@ -24,7 +24,8 @@ int numpassed (void);
 int numfailed (void);
 int is_make_silent (void);
 
-static inline void pass (void);
+static inline void pass_ (const char *name);
+#define pass() pass_ (__func__)
 static void fail (const char *fmt, ...) ATTRIBUTE_FORMAT (1, 2);
 static void ok (const char *fmt, ...) ATTRIBUTE_FORMAT (1, 2);
 
@@ -52,10 +53,13 @@ static void ATTRIBUTE_FORMAT (1, 2) ok (const char *fmt, ...)
 }
 
 static inline void
-pass (void)
+pass_ (const char *name)
 {
   passed++;
-  num++;
+  if (loglevel >= 2)
+    printf ("ok %d  # %s\n", ++num, name);
+  else
+    num++;
 }
 
 static void ATTRIBUTE_FORMAT (1, 2) fail (const char *fmt, ...)


### PR DESCRIPTION
The result in loglevel > 2 is:
```
> ./bits_test
ok 1  # bit_read_B_tests
ok 2  # bit_write_B_tests
ok 3    # bit_advance_position
ok 4  # bit_read_BB_tests
ok 5  # bit_read_BB_tests
ok 6  # bit_write_BB_tests
ok 7  # bit_write_BB_tests
ok 8  # bit_read_4BITS_tests
ok 9  # bit_read_4BITS_tests
ok 10  # bit_read_4BITS_tests
ok 11  # bit_read_4BITS_tests
ok 12  # bit_read_4BITS_tests
ok 13  # bit_read_4BITS_tests
ok 14  # bit_read_4BITS_tests
ok 15  # bit_read_4BITS_tests
ok 16  # bit_read_4BITS_tests
ok 17  # bit_read_4BITS_tests
ok 18  # bit_read_4BITS_tests
ok 19  # bit_read_4BITS_tests
ok 20  # bit_read_4BITS_tests
ok 21  # bit_read_4BITS_tests
ok 22  # bit_read_4BITS_tests
ok 23  # bit_read_4BITS_tests
ok 24  # bit_write_4BITS_tests
ok 25  # bit_BLL_tests
ok 26  # bit_BLL_tests
ok 27  # bit_BLL_tests
ok 28  # bit_BLL_tests
ok 29  # bit_BLL_tests
ok 30  # bit_BLL_tests
...
```