### PR TITLE
encode: free imported class dxfname before replacing it

### DIFF
--- a/src/encode.c
+++ b/src/encode.c
@@ -5928,7 +5928,10 @@ dwg_encode_get_class (Dwg_Data *dwg, Dwg_Object *obj)
                   // a static string, which cannot be free'd. important for
                   // indxf
                   if (dwg->opts & DWG_OPTS_IN)
-                    obj->dxfname = strdup ((char *)alias);
+                    {
+                      free (obj->dxfname);
+                      obj->dxfname = strdup ((char *)alias);
+                    }
                   else
                     obj->dxfname = (char *)alias;
                   obj->type = 500 + i;
@@ -5956,7 +5959,10 @@ dwg_encode_get_class (Dwg_Data *dwg, Dwg_Object *obj)
       if (!klass->dxfname)
         return NULL;
       if (dwg->opts & DWG_OPTS_IN)
-        obj->dxfname = strdup (klass->dxfname);
+        {
+          free (obj->dxfname);
+          obj->dxfname = strdup (klass->dxfname);
+        }
       else
         obj->dxfname = klass->dxfname;
     }


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Imported DXF objects own their duplicated dxfname. Free that string before replacing it with a class alias or class dxfname during encode-time class lookup.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/encode.c (dwg_encode_get_class): Free IN-mode object dxfname before assigning a new duplicate.