### PR TITLE
Improve 3dline entity handling

### DIFF
--- a/examples/dwgadd.5
+++ b/examples/dwgadd.5
@@ -113,6 +113,10 @@ Assign "VALUES" to a HEADER field. See the full documentation of valid HEADER fi
 .PD
 Create a line variable and entity. You may set all other fields via the
 \&\f(CW\*(C`line.field = value\*(C'\fR syntax. E.g. \f(CW\*(C`line.layer = "0"\*(C'\fR
+.IP "\fB3dline\fR (3dpoint) (3dpoint)" 4
+.IX Item "3dline (3dpoint) (3dpoint)"
+Explicit 3D line command. Writes a 3DLINE entity for DWG versions r2.4
+through r10, and a LINE entity for r11 and later.
 .IP "\fBray\fR (3dpoint) (3dpoint)" 4
 .IX Item "ray (3dpoint) (3dpoint)"
 .PD 0

--- a/examples/dwgadd.c
+++ b/examples/dwgadd.c
@@ -641,6 +641,7 @@ dwg_add_dat (Dwg_Data **dwgp, Bit_Chain *dat)
       Dwg_Entity_ATTDEF *attdef;
       Dwg_Entity_ATTRIB *attrib;
       Dwg_Entity_LINE *line;
+      Dwg_Entity__3DLINE *_3dline;
       Dwg_Entity_RAY *ray;
       Dwg_Entity_XLINE *xline;
       Dwg_Entity_CIRCLE *circle;
@@ -1120,6 +1121,26 @@ dwg_add_dat (Dwg_Data **dwgp, Bit_Chain *dat)
       else
           // clang-format off
         SET_ENT (attrib, ATTRIB)
+      // clang-format on
+      else if (6
+               == SSCANF_S (p, "3dline (%lf %lf %lf) (%lf %lf %lf)", &pt1.x,
+                            &pt1.y, &pt1.z, &pt2.x, &pt2.y, &pt2.z))
+      {
+        if (version < R_2_4)
+          fn_error ("Invalid entity 3DLINE\n");
+        LOG_TRACE ("add_3DLINE %s (%f %f %f) (%f %f %f)\n", hdr_s, pt1.x,
+                   pt1.y, pt1.z, pt2.x, pt2.y, pt2.z);
+        CHK_MISSING_BLOCK_HEADER
+        if (version < R_11)
+          ent = (lastent_t){ .u._3dline = dwg_add_3DLINE (hdr, &pt1, &pt2),
+                             .type = DWG_TYPE__3DLINE };
+        else
+          ent = (lastent_t){ .u.line = dwg_add_LINE (hdr, &pt1, &pt2),
+                             .type = DWG_TYPE_LINE };
+      }
+      else
+          // clang-format off
+        SET_ENT (_3dline, _3DLINE)
       // clang-format on
       else if (6
                == SSCANF_S (p, "line (%lf %lf %lf) (%lf %lf %lf)", &pt1.x,

--- a/include/dwg.h
+++ b/include/dwg.h
@@ -9472,6 +9472,7 @@ typedef struct _dwg_object_entity
     /* Start auto-generated entity-union. Do not touch. */
     // clang-format: off
     Dwg_Entity__3DFACE *_3DFACE;
+    Dwg_Entity__3DLINE *_3DLINE;
     Dwg_Entity__3DSOLID *_3DSOLID;
     Dwg_Entity_ARC *ARC;
     Dwg_Entity_ATTDEF *ATTDEF;
@@ -9520,7 +9521,6 @@ typedef struct _dwg_object_entity
     Dwg_Entity_VIEWPORT *VIEWPORT;
     Dwg_Entity_XLINE *XLINE;
     /* untyped > 500 */
-    Dwg_Entity__3DLINE *_3DLINE;
     Dwg_Entity_ARC_DIMENSION *ARC_DIMENSION;
     Dwg_Entity_CAMERA *CAMERA;
     Dwg_Entity_DGNUNDERLAY *DGNUNDERLAY;
@@ -11768,6 +11768,7 @@ EXPORT int dwg_object_name (const char *const restrict name, // in
 /* Start auto-generated content. Do not touch. */
 // clang-format: off
 EXPORT int dwg_setup__3DFACE (Dwg_Object *obj);
+EXPORT int dwg_setup__3DLINE (Dwg_Object *obj);
 EXPORT int dwg_setup__3DSOLID (Dwg_Object *obj);
 EXPORT int dwg_setup_ARC (Dwg_Object *obj);
 EXPORT int dwg_setup_ATTDEF (Dwg_Object *obj);
@@ -11841,7 +11842,6 @@ EXPORT int dwg_setup_VPORT_CONTROL (Dwg_Object *obj);
 EXPORT int dwg_setup_VX_CONTROL (Dwg_Object *obj);
 EXPORT int dwg_setup_VX_TABLE_RECORD (Dwg_Object *obj);
 /* untyped > 500 */
-EXPORT int dwg_setup__3DLINE (Dwg_Object *obj);
 EXPORT int dwg_setup_ARC_DIMENSION (Dwg_Object *obj);
 EXPORT int dwg_setup_CAMERA (Dwg_Object *obj);
 EXPORT int dwg_setup_DGNUNDERLAY (Dwg_Object *obj);

--- a/include/dwg_api.h
+++ b/include/dwg_api.h
@@ -548,6 +548,7 @@ extern "C"
   /* Start auto-generated content. Do not touch. */
   // clang-format: off
   typedef struct _dwg_entity__3DFACE		dwg_ent__3dface;
+  typedef struct _dwg_entity_3DLINE		dwg_ent__3dline;
   typedef struct _dwg_entity__3DSOLID		dwg_ent__3dsolid;
   typedef struct _dwg_entity_ARC		dwg_ent_arc;
   typedef struct _dwg_entity_ATTDEF		dwg_ent_attdef;
@@ -591,7 +592,6 @@ extern "C"
   typedef struct _dwg_entity_VERTEX_PFACE_FACE		dwg_ent_vert_pface_face;
   typedef struct _dwg_entity_VIEWPORT		dwg_ent_viewport;
   /* untyped > 500 */
-  typedef struct _dwg_entity_3DLINE		dwg_ent__3dline;
   typedef struct _dwg_entity_ARC_DIMENSION		dwg_ent_arc_dimension;
   typedef struct _dwg_entity_CAMERA		dwg_ent_camera;
   typedef struct _dwg_entity_DGNUNDERLAY		dwg_ent_dgnunderlay;
@@ -1672,6 +1672,7 @@ extern "C"
 
 
   dwg_get_OBJECT_DECL (ent__3dface, _3DFACE);
+  dwg_get_OBJECT_DECL (ent__3dline, _3DLINE);
   dwg_get_OBJECT_DECL (ent__3dsolid, _3DSOLID);
   dwg_get_OBJECT_DECL (ent_arc, ARC);
   dwg_get_OBJECT_DECL (ent_attdef, ATTDEF);
@@ -1715,7 +1716,6 @@ extern "C"
   dwg_get_OBJECT_DECL (ent_vert_pface_face, VERTEX_PFACE_FACE);
   dwg_get_OBJECT_DECL (ent_viewport, VIEWPORT);
   /* untyped > 500 */
-  dwg_get_OBJECT_DECL (ent__3dline, _3DLINE);
   dwg_get_OBJECT_DECL (ent_arc_dimension, ARC_DIMENSION);
   dwg_get_OBJECT_DECL (ent_camera, CAMERA);
   dwg_get_OBJECT_DECL (ent_dgnunderlay, DGNUNDERLAY);
@@ -2803,6 +2803,7 @@ extern "C"
 
 /// extract all owned entities from a block header (mspace or pspace)
   DWG_GETALL_ENTITY_DECL (_3DFACE);
+  DWG_GETALL_ENTITY_DECL (_3DLINE);
   DWG_GETALL_ENTITY_DECL (_3DSOLID);
   DWG_GETALL_ENTITY_DECL (ARC);
   DWG_GETALL_ENTITY_DECL (ATTDEF);
@@ -2851,7 +2852,6 @@ extern "C"
   DWG_GETALL_ENTITY_DECL (VIEWPORT);
   DWG_GETALL_ENTITY_DECL (XLINE);
   /* untyped > 500 */
-  DWG_GETALL_ENTITY_DECL (_3DLINE);
   DWG_GETALL_ENTITY_DECL (ARC_DIMENSION);
   DWG_GETALL_ENTITY_DECL (CAMERA);
   DWG_GETALL_ENTITY_DECL (DGNUNDERLAY);
@@ -3954,6 +3954,7 @@ extern "C"
  */
 /* fixed <500 */
   CAST_DWG_OBJECT_TO_ENTITY_DECL (_3DFACE);
+  CAST_DWG_OBJECT_TO_ENTITY_DECL (_3DLINE);
   CAST_DWG_OBJECT_TO_ENTITY_DECL (_3DSOLID);
   CAST_DWG_OBJECT_TO_ENTITY_DECL (ARC);
   CAST_DWG_OBJECT_TO_ENTITY_DECL (ATTDEF);
@@ -4002,7 +4003,6 @@ extern "C"
   CAST_DWG_OBJECT_TO_ENTITY_DECL (VIEWPORT);
   CAST_DWG_OBJECT_TO_ENTITY_DECL (XLINE);
   /* untyped > 500 */
-  CAST_DWG_OBJECT_TO_ENTITY_BYNAME_DECL (_3DLINE);
   CAST_DWG_OBJECT_TO_ENTITY_BYNAME_DECL (ARC_DIMENSION);
   CAST_DWG_OBJECT_TO_ENTITY_BYNAME_DECL (CAMERA);
   CAST_DWG_OBJECT_TO_ENTITY_BYNAME_DECL (DGNUNDERLAY);
@@ -9590,6 +9590,10 @@ extern "C"
   dwg_add_LINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
                 const dwg_point_3d *restrict start_pt,
                 const dwg_point_3d *restrict end_pt) __nonnull_all;
+  EXPORT Dwg_Entity__3DLINE *
+  dwg_add_3DLINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
+                  const dwg_point_3d *restrict start_pt,
+                  const dwg_point_3d *restrict end_pt) __nonnull_all;
   EXPORT Dwg_Entity_DIMENSION_ALIGNED *dwg_add_DIMENSION_ALIGNED (
       Dwg_Object_BLOCK_HEADER *restrict blkhdr,
       const dwg_point_3d *restrict xline1_pt,

--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -26663,7 +26663,12 @@ dwg_add_LINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
               const dwg_point_3d *restrict start_pt,
               const dwg_point_3d *restrict end_pt)
 {
-  API_ADD_ENTITY (LINE);
+  API_ADD_PREP (LINE);
+  if (dwg->header.version >= R_2_4 && dwg->header.version < R_10
+      && (start_pt->z != 0.0 || end_pt->z != 0.0))
+    return (Dwg_Entity_LINE *)dwg_add_3DLINE (blkhdr, start_pt, end_pt);
+
+  API_ADD_ENTITY2 (LINE);
   ADD_CHECK_3DPOINT (start_pt);
   ADD_CHECK_3DPOINT (end_pt);
   _obj->start.x = start_pt->x;
@@ -26675,22 +26680,6 @@ dwg_add_LINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
 
   if (dwg->header.version <= R_11)
     obj->type = DWG_TYPE_LINE_r11;
-  // In case of 3d line we are changing type to 3DLINE entity
-  if (dwg->header.version >= R_2_4 && dwg->header.version < R_10)
-    {
-      if (_obj->start.z != 0.0)
-        {
-          obj->type = DWG_TYPE_3DLINE_r11;
-          obj->fixedtype = DWG_TYPE__3DLINE;
-          obj->tio.entity->opts_r11 |= 1;
-        }
-      if (_obj->end.z != 0.0)
-        {
-          obj->type = DWG_TYPE_3DLINE_r11;
-          obj->fixedtype = DWG_TYPE__3DLINE;
-          obj->tio.entity->opts_r11 |= 2;
-        }
-    }
   // There is 3DLINE entity in R_10, but duplicit with LINE
   if (dwg->header.version == R_10)
     {

--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -254,7 +254,6 @@ dwg_get_OBJECT (ent_viewport, VIEWPORT)
 /* Start auto-generated content. Do not touch. */
 // clang-format: off
 /* untyped > 500 */
-dwg_get_OBJECT (ent__3dline, _3DLINE)
 dwg_get_OBJECT (ent_arc_dimension, ARC_DIMENSION)
 dwg_get_OBJECT (ent_camera, CAMERA)
 dwg_get_OBJECT (ent_dgnunderlay, DGNUNDERLAY)
@@ -2510,6 +2509,7 @@ DWG_GETALL_OBJECT (ASSOCARRAYRECTANGULARPARAMETERS)
 // clang-format: off
 /* fixed <500 */
 CAST_DWG_OBJECT_TO_ENTITY (_3DFACE)
+CAST_DWG_OBJECT_TO_ENTITY (_3DLINE)
 CAST_DWG_OBJECT_TO_ENTITY (_3DSOLID)
 CAST_DWG_OBJECT_TO_ENTITY (ARC)
 CAST_DWG_OBJECT_TO_ENTITY (ATTDEF)
@@ -2558,7 +2558,6 @@ CAST_DWG_OBJECT_TO_ENTITY (VERTEX_PFACE_FACE)
 CAST_DWG_OBJECT_TO_ENTITY (VIEWPORT)
 CAST_DWG_OBJECT_TO_ENTITY (XLINE)
 /* untyped > 500 */
-CAST_DWG_OBJECT_TO_ENTITY_BYNAME (_3DLINE)
 CAST_DWG_OBJECT_TO_ENTITY_BYNAME (ARC_DIMENSION)
 CAST_DWG_OBJECT_TO_ENTITY_BYNAME (CAMERA)
 CAST_DWG_OBJECT_TO_ENTITY_BYNAME (DGNUNDERLAY)
@@ -26692,9 +26691,44 @@ dwg_add_LINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
           obj->tio.entity->opts_r11 |= 2;
         }
     }
-  // There is 3DLINE entity in R_10, but duplicit with LINE (without
-  // HAS_ELEVATION)
+  // There is 3DLINE entity in R_10, but duplicit with LINE
   if (dwg->header.version == R_10)
+    {
+      if (_obj->start.z == 0.0 && _obj->end.z == 0.0)
+        obj->tio.entity->flag_r11 |= FLAG_R11_HAS_ELEVATION;
+    }
+  return _obj;
+}
+
+EXPORT Dwg_Entity__3DLINE *
+dwg_add_3DLINE (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
+                const dwg_point_3d *restrict start_pt,
+                const dwg_point_3d *restrict end_pt)
+{
+  API_ADD_ENTITY (_3DLINE);
+  if (dwg->header.version < R_2_4 || dwg->header.version > R_10)
+    {
+      LOG_ERROR ("Invalid entity %s for this DWG version", "3DLINE");
+      API_UNADD_ENTITY;
+      return NULL;
+    }
+  ADD_CHECK_3DPOINT (start_pt);
+  ADD_CHECK_3DPOINT (end_pt);
+  _obj->start.x = start_pt->x;
+  _obj->start.y = start_pt->y;
+  _obj->start.z = start_pt->z;
+  _obj->end.x = end_pt->x;
+  _obj->end.y = end_pt->y;
+  _obj->end.z = end_pt->z;
+  obj->type = DWG_TYPE_3DLINE_r11;
+  if (dwg->header.version < R_10)
+    {
+      if (_obj->start.z != 0.0)
+        obj->tio.entity->opts_r11 |= 1;
+      if (_obj->end.z != 0.0)
+        obj->tio.entity->opts_r11 |= 2;
+    }
+  else
     {
       if (_obj->start.z == 0.0 && _obj->end.z == 0.0)
         obj->tio.entity->flag_r11 |= FLAG_R11_HAS_ELEVATION;

--- a/src/gen-dynapi.pl
+++ b/src/gen-dynapi.pl
@@ -2143,12 +2143,10 @@ for (@object_names) {
 }
 $STABLE{_3DSOLID}++;
 $STABLE{_3DFACE}++;
-
-# $UNSTABLE{_3DLINE}++;
-delete $STABLE{'3DLINE'};
-delete $FIXED{'3DLINE'};
+$STABLE{_3DLINE}++;
 $FIXED{_3DSOLID}++;
 $FIXED{_3DFACE}++;
+$FIXED{_3DLINE}++;
 for ( keys %STABLE ) {
     $STABLEVAR{$_}++ unless $FIXED{$_};
 }

--- a/test/unit-testing/add_test.c
+++ b/test/unit-testing/add_test.c
@@ -132,8 +132,11 @@ test_add (const Dwg_Object_Type type, const char *restrict file,
       ok ("LIBREDWG_DEBUG cnt %d %s", cnt, name);
     }
 
-  dwg = dwg_new_Document (as_dxf ? R_2018 : R_2000, 0 /*metric/iso */,
-                          tracelevel);
+  dwg = dwg_new_Document (
+      type == DWG_TYPE__3DLINE                   ? R_9
+      : as_dxf                                 ? R_2018
+                                               : R_2000,
+      0 /*metric/iso */, tracelevel);
   mspace = dwg_model_space_object (dwg);
   mspace_ref = dwg_model_space_ref (dwg);
   if (!mspace)
@@ -287,6 +290,13 @@ test_add (const Dwg_Object_Type type, const char *restrict file,
       {
         const dwg_point_3d pt3 = { 2.5, 0.0, 0.0 };
         dwg_add_3DFACE (hdr, &pt1, &pt2, &pt3, NULL);
+      }
+      break;
+    case DWG_TYPE__3DLINE:
+      {
+        const dwg_point_3d pt3d_1 = { 1.0, 2.0, 3.0 };
+        const dwg_point_3d pt3d_2 = { 4.0, 5.0, 6.0 };
+        dwg_add_3DLINE (hdr, &pt3d_1, &pt3d_2);
       }
       break;
     case DWG_TYPE_SOLID:
@@ -905,6 +915,7 @@ test_add (const Dwg_Object_Type type, const char *restrict file,
       TEST_ENTITY (DIMENSION_LINEAR);
       TEST_ENTITY (POINT);
       TEST_ENTITY (_3DFACE);
+      TEST_ENTITY (_3DLINE);
       TEST_ENTITY (SOLID);
       TEST_ENTITY (TRACE);
       TEST_ENTITY (SHAPE);
@@ -1507,6 +1518,7 @@ main (int argc, char *argv[])
       error += test_add (DWG_TYPE_DIMENSION_LINEAR, "add_dimlin_2000", dxf);
       error += test_add (DWG_TYPE_POINT, "add_point_2000", dxf);
       error += test_add (DWG_TYPE__3DFACE, "add_3dface_2000", dxf);
+      error += test_add (DWG_TYPE__3DLINE, "add_3dline_r9", dxf);
       error += test_add (DWG_TYPE_SOLID, "add_solid_2000", dxf);
       error += test_add (DWG_TYPE_TRACE, "add_trace_2000", dxf);
       error += test_add (DWG_TYPE_SHAPE, "add_shape_2000", dxf);


### PR DESCRIPTION
Added 3dline command to dwgadd to simulate similar behaviour as script in old AutoCADs.
It uses new dwg_add_3DLINE API function.
Fixed old dwg_add_LINE in retype to 3DLINE.
Added tests.