### PR TITLE
in_dxf: free MLINESTYLE lines before reallocating

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -2467,6 +2467,8 @@ add_MLINESTYLE_lines (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   int num_lines = pair->value.i;
   Dwg_Object_MLINESTYLE *o = obj->tio.object->tio.MLINESTYLE;
   Dwg_Data *dwg = obj->parent;
+  free (o->lines);
+  o->lines = NULL;
   o->num_lines = num_lines;
   LOG_TRACE ("MLINESTYLE.num_lines = %d [RC 71]\n", num_lines);
   o->lines = (Dwg_MLINESTYLE_line *)xcalloc (num_lines,


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free the existing MLINESTYLE line array before rebuilding it from the DXF line count so repeated or restarted parsing does not leak the old allocation.

This does not overlap the parsing or semantics scope of PR [#1312](https://github.com/LibreDWG/libredwg/issues/1312)-[#1322](https://github.com/LibreDWG/libredwg/issues/1322).

* src/in_dxf.c (add_MLINESTYLE_lines): Free the old lines array before allocating the replacement.