### PR TITLE
in_dxf: free MATERIAL map strings before replacing them

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -9779,6 +9779,8 @@ add_MATERIAL (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   // a map filename (source==1), kept as UTF-8 like all other imported strings
 #  define MAT_T(field, dxf)                                                   \
     case dxf:                                                                 \
+      free (o->field);                                                        \
+      o->field = NULL;                                                        \
       o->field = pair->value.s.ptr ? strdup (pair->value.s.ptr) : NULL;       \
       LOG_TRACE ("MATERIAL." #field " = %s [T %d]\n",                         \
                  pair->value.s.ptr ? pair->value.s.ptr : "", pair->code);     \


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free existing imported MATERIAL map filename strings before assigning replacement duplicates from DXF input.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (add_MATERIAL): Free MAT_T string fields before strdup replacement.