### PR TITLE
in_dxf: free PERSUBENTMGR arrays before reallocating

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -6735,6 +6735,8 @@ add_PERSUBENTMGR (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   FIELD_BL (numassocsteps, 90);
   FIELD_BL (numassocsubents, 90);
   FIELD_BL (num_steps, 90);
+  free (o->steps);
+  o->steps = NULL;
   if (o->num_steps > 0)
     {
       o->steps = (BITCODE_BL *)xcalloc (o->num_steps, sizeof (BITCODE_BL));
@@ -6755,6 +6757,8 @@ add_PERSUBENTMGR (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         }
     }
   FIELD_BL (num_subents, 90);
+  free (o->subents);
+  o->subents = NULL;
   if (o->num_subents > 0)
     {
       o->subents = (BITCODE_BL *)xcalloc (o->num_subents, sizeof (BITCODE_BL));


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free the existing PERSUBENTMGR steps and subents arrays before rebuilding them from DXF counts.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (add_PERSUBENTMGR): Free steps and subents before replacement allocation.