### PR TITLE
in_dxf: free SECTIONVIEWSTYLE hatch angles before rebuilding

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -9229,6 +9229,9 @@ add_AcDbSectionViewStyle (Dwg_Object *restrict obj, Bit_Chain *restrict dat)
   FIELD_BLd (hatch_transparency, 90);
   FIELD_B (unknown_b1, 290);
   FIELD_B (unknown_b2, 290);
+  free (o->hatch_angles);
+  o->hatch_angles = NULL;
+  o->num_hatch_angles = 0;
   FIELD_BL (num_hatch_angles, 90);
   if (o->num_hatch_angles)
     {


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free the existing SECTIONVIEWSTYLE hatch_angles vector before reading a replacement vector from DXF input.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (add_AcDbSectionViewStyle): Free hatch_angles before replacement allocation.