### PR TITLE
in_dxf: free MESH arrays before rebuilding vectors

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -2859,6 +2859,8 @@ add_MESH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   if (pair->code == 91)
     {
       vector = pair->code;
+      free (o->subdiv_vertex);
+      o->subdiv_vertex = NULL;
       o->num_subdiv_vertex = pair->value.u;
       LOG_TRACE ("MESH.num_subdiv_vertex = %u [BL 91]\n", pair->value.u);
       if (pair->value.u)
@@ -2884,6 +2886,8 @@ add_MESH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         {
           j = 0;
           vector = pair->code;
+          free (o->vertex);
+          o->vertex = NULL;
           o->num_vertex = pair->value.u;
           LOG_TRACE ("MESH.num_vertex = %u [BL 92]\n", pair->value.u);
           if (pair->value.u)
@@ -2901,6 +2905,8 @@ add_MESH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         {
           j = 0;
           vector = pair->code;
+          free (o->faces);
+          o->faces = NULL;
           o->num_faces = pair->value.u;
           LOG_TRACE ("MESH.num_faces = %u [BL %d]\n", pair->value.u,
                      pair->code);
@@ -2919,6 +2925,8 @@ add_MESH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         {
           j = 0;
           vector = pair->code;
+          free (o->edges);
+          o->edges = NULL;
           o->num_edges = pair->value.u;
           LOG_TRACE ("MESH.num_edges = %u [BL %d]\n", pair->value.u,
                      pair->code);
@@ -2937,6 +2945,8 @@ add_MESH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         {
           j = 0;
           vector = pair->code;
+          free (o->crease);
+          o->crease = NULL;
           o->num_crease = pair->value.u;
           LOG_TRACE ("MESH.num_crease = %u [BL %d]\n", pair->value.u,
                      pair->code);
@@ -3032,6 +3042,8 @@ add_MESH (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
             }
           else if (vector == 95)
             {
+              free (o->crease);
+              o->crease = NULL;
               o->num_crease = pair->value.u;
               LOG_TRACE ("MESH.num_crease = %u [BL %d]\n", pair->value.u,
                          pair->code);


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free existing MESH subdivision, vertex, face, edge, and crease arrays before rebuilding each vector from DXF input.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (add_MESH): Free old vector arrays before allocating replacements.