### PR TITLE
in_dxf: free GEODATA mesh arrays before reallocating

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -380,6 +380,28 @@ xcalloc (size_t n, size_t s)
 
 #ifndef DISABLE_DXF
 
+static void
+free_GEODATA_geomesh_pts (Dwg_Object_GEODATA *restrict geodata)
+{
+  if (!geodata)
+    return;
+
+  free (geodata->geomesh_pts);
+  geodata->geomesh_pts = NULL;
+  geodata->num_geomesh_pts = 0;
+}
+
+static void
+free_GEODATA_geomesh_faces (Dwg_Object_GEODATA *restrict geodata)
+{
+  if (!geodata)
+    return;
+
+  free (geodata->geomesh_faces);
+  geodata->geomesh_faces = NULL;
+  geodata->num_geomesh_faces = 0;
+}
+
 /* With mips32 -O2 inline would fail. */
 static void
 dxf_skip_ws (Bit_Chain *dat)
@@ -4973,6 +4995,7 @@ add_GEODATA (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         {
         case 93:
           i = -1;
+          free_GEODATA_geomesh_pts (o);
           o->num_geomesh_pts = pair->value.u;
           o->geomesh_pts = (Dwg_GEODATA_meshpt *)xcalloc (
               pair->value.u, sizeof (Dwg_GEODATA_meshpt));
@@ -4983,6 +5006,7 @@ add_GEODATA (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
           break;
         case 96:
           i = -1;
+          free_GEODATA_geomesh_faces (o);
           o->num_geomesh_faces = pair->value.u;
           o->geomesh_faces = (Dwg_GEODATA_meshface *)xcalloc (
               pair->value.u, sizeof (Dwg_GEODATA_meshface));


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free existing geomesh point and face arrays before rebuilding them from DXF counts, avoiding leaks when the importer sees replacement mesh data.

For commits considered too large, a request for a GNU copyright assignment covering PAST AND FUTURE CHANGES has been sent already.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (free_GEODATA_geomesh_pts): New helper.

* src/in_dxf.c (free_GEODATA_geomesh_faces): New helper.

* src/in_dxf.c (add_GEODATA): Free existing mesh arrays before replacement.



The remaining PR's I have fixing similar issues all have helpers, sometimes called once, sometimes called at multiple sites. Please let me know if there is a style preference when they are called once.