### PR TITLE
in_dxf: free TABLESTYLE and CellStyle strings before replacing them

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -381,6 +381,17 @@ xcalloc (size_t n, size_t s)
 #ifndef DISABLE_DXF
 
 static void
+free_CellStyle_borders (Dwg_CellStyle *restrict cellstyle)
+{
+  if (!cellstyle)
+    return;
+
+  free (cellstyle->borders);
+  cellstyle->borders = NULL;
+  cellstyle->num_borders = 0;
+}
+
+static void
 free_GEODATA_geomesh_pts (Dwg_Object_GEODATA *restrict geodata)
 {
   if (!geodata)
@@ -5139,6 +5150,8 @@ add_CellStyle (Dwg_Object *restrict obj, Dwg_CellStyle *o, const char *key,
         case 300:
           if (mode == CONTENTFORMAT)
             {
+              free (o->content_format.value_format_string);
+              o->content_format.value_format_string = NULL;
               if (obj->parent->header.version >= R_2007)
                 o->content_format.value_format_string
                     = (BITCODE_T)bit_utf8_to_TU (pair->value.s.ptr, 0);
@@ -5295,6 +5308,7 @@ add_CellStyle (Dwg_Object *restrict obj, Dwg_CellStyle *o, const char *key,
         case 94:
           if (mode == TABLEFORMAT)
             {
+              free_CellStyle_borders (o);
               o->num_borders = pair->value.u;
               j = 0;
               LOG_TRACE ("%s.%s.num_borders = " FORMAT_BL " [BL %d]\n",
@@ -5595,6 +5609,8 @@ add_TABLESTYLE (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
           break;
         case 1:
           CHK_rowstyles;
+          free (o->rowstyles[i].format_string);
+          o->rowstyles[i].format_string = NULL;
           o->rowstyles[i].format_string
               = bit_utf8_to_TU (pair->value.s.ptr, 0);
           LOG_TRACE ("%s.rowstyles[%d].format_string = %s [TU %d]\n",


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free CellStyle value-format strings, CellStyle borders, and TABLESTYLE rowstyle format strings before rebuilding replacement data from DXF input.

For commits considered too large, a request for a GNU copyright assignment covering PAST AND FUTURE CHANGES has been sent already.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (free_CellStyle_borders): New helper.

* src/in_dxf.c (add_CellStyle): Free value format strings and border arrays before replacement.

* src/in_dxf.c (add_TABLESTYLE): Free rowstyle format strings before replacement.
