### PR TITLE
in_dxf: grow DICTIONARY item arrays through temporaries

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -7743,6 +7743,8 @@ add_dictionary_itemhandles (Dwg_Object *restrict obj, Dxf_Pair *restrict pair,
   Dwg_Data *dwg = obj->parent;
   BITCODE_BL num;
   BITCODE_H hdl;
+  BITCODE_H *itemhandles;
+  BITCODE_TV *texts;
 
   if (pair->code == 360)
     _obj->is_hardowner = 1;
@@ -7750,15 +7752,21 @@ add_dictionary_itemhandles (Dwg_Object *restrict obj, Dxf_Pair *restrict pair,
   hdl = dwg_add_handleref (dwg, 2, pair->value.u, obj);
   LOG_TRACE ("%s.itemhandles[%d] = " FORMAT_REF " [H* %d]\n", obj->name, num,
              ARGS_REF (hdl), pair->code);
-  _obj->itemhandles = (BITCODE_H *)realloc (_obj->itemhandles,
-                                            (num + 1) * sizeof (BITCODE_H));
-  _obj->texts
-      = (BITCODE_TV *)realloc (_obj->texts, (num + 1) * sizeof (BITCODE_TV));
-  if (!_obj->itemhandles || !_obj->texts)
+  itemhandles = (BITCODE_H *)realloc (_obj->itemhandles,
+                                      (num + 1) * sizeof (BITCODE_H));
+  if (!itemhandles)
     {
       LOG_ERROR ("Out of memory");
       return;
     }
+  _obj->itemhandles = itemhandles;
+  texts = (BITCODE_TV *)realloc (_obj->texts, (num + 1) * sizeof (BITCODE_TV));
+  if (!texts)
+    {
+      LOG_ERROR ("Out of memory");
+      return;
+    }
+  _obj->texts = texts;
   _obj->itemhandles[num] = hdl;
   _obj->texts[num] = dwg_add_u8_input (dwg, text);
   LOG_TRACE ("%s.texts[%d] = %s [T* 3]\n", obj->name, num, text);


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Grow DICTIONARY itemhandles and texts through temporary variables before assigning them back, so a failed realloc does not overwrite the original pointers.

This explicitly captures the temporary-allocation rewrite used to avoid losing existing allocations on growth failure.

For commits considered too large, a request for a GNU copyright assignment covering PAST AND FUTURE CHANGES has been sent already.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (add_dictionary_itemhandles): Use temporary realloc results for itemhandles and texts before assigning them back.
