### PR TITLE
in_dxf: free preview buffers before rebuilding

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -7782,6 +7782,9 @@ add_ent_preview (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
       LOG_ERROR ("%s is no entity for a preview", obj->name);
       return pair;
     }
+  free (ent->preview);
+  ent->preview = NULL;
+  ent->preview_exists = 0;
   ent->preview_size = pair->code == 160  ? pair->value.rll
                       : pair->code == 92 ? pair->value.u
                                          : 0;
@@ -7818,7 +7821,16 @@ add_ent_preview (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
       BITCODE_TF s;
 
       if (!ent->preview_size)
-        ent->preview = (BITCODE_TF)realloc (ent->preview, written + blen);
+        {
+          BITCODE_TF preview;
+          preview = (BITCODE_TF)realloc (ent->preview, written + blen);
+          if (!preview)
+            {
+              LOG_ERROR ("Out of memory");
+              return NULL;
+            }
+          ent->preview = preview;
+        }
       else if (blen + written > ent->preview_size)
         {
           LOG_ERROR ("%s.preview overflow: %" PRIuSIZE " + written %" PRIuSIZE
@@ -7862,6 +7874,9 @@ add_block_preview (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
                  pair->code);
       return pair;
     }
+  free (_obj->preview);
+  _obj->preview = NULL;
+  _obj->preview_size = 0;
   while (pair != NULL && pair->code == 310)
     {
       const char *pos = pair->value.s.ptr;
@@ -7870,8 +7885,14 @@ add_block_preview (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         const size_t blen = pair->value.s.len;
         if (blen)
           {
-            _obj->preview
-                = (BITCODE_TF)realloc (_obj->preview, written + blen);
+            BITCODE_TF preview;
+            preview = (BITCODE_TF)realloc (_obj->preview, written + blen);
+            if (!preview)
+              {
+                LOG_ERROR ("Out of memory");
+                return NULL;
+              }
+            _obj->preview = preview;
             memcpy (&_obj->preview[written], pos, blen);
             written += blen;
             LOG_TRACE ("BLOCK_HEADER.preview += %" PRIuSIZE " (%" PRIuSIZE


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free existing entity and block preview buffers before reading replacement preview data, and grow preview buffers through temporary variables before assigning them back.

This explicitly captures the temporary-allocation rewrite used for preview buffer growth.

For commits considered too large, a request for a GNU copyright assignment covering PAST AND FUTURE CHANGES has been sent already.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (add_ent_preview): Free existing preview data and assign realloc results through a temporary.

* src/in_dxf.c (add_block_preview): Free existing preview data and assign realloc results through a temporary.
