### PR TITLE
in_dxf: free LTYPE dash data before rebuilding

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -402,6 +402,30 @@ free_GEODATA_geomesh_faces (Dwg_Object_GEODATA *restrict geodata)
   geodata->num_geomesh_faces = 0;
 }
 
+static void
+free_LTYPE_dashes (Dwg_Object_LTYPE *restrict ltype)
+{
+  int i;
+
+  if (!ltype)
+    return;
+
+  if (ltype->dashes)
+    {
+      for (i = 0; i < (int)ltype->numdashes; i++)
+        {
+          free (ltype->dashes[i].text);
+          ltype->dashes[i].text = NULL;
+        }
+      free (ltype->dashes);
+      ltype->dashes = NULL;
+    }
+  free (ltype->strings_area);
+  ltype->strings_area = NULL;
+  ltype->numdashes = 0;
+  ltype->has_strings_area = 0;
+}
+
 /* With mips32 -O2 inline would fail. */
 static void
 dxf_skip_ws (Bit_Chain *dat)
@@ -2356,6 +2380,8 @@ add_LTYPE_dashes (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   int is_tu = 0;
   unsigned dash_i = 0;
 
+  free_LTYPE_dashes (o);
+  o->numdashes = (BITCODE_RC)num_dashes;
   o->dashes
       = (Dwg_LTYPE_dash *)xcalloc (o->numdashes, sizeof (Dwg_LTYPE_dash));
   if (!o->dashes)
@@ -2440,6 +2466,8 @@ add_LTYPE_dashes (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
           size_t strings_size, needed;
           is_tu = obj->parent->header.version >= R_2007;
           CHK_dashes (j, dashes);
+          free (o->dashes[j].text);
+          o->dashes[j].text = NULL;
           o->dashes[j].text
               = dwg_add_u8_input (obj->parent, pair->value.s.ptr);
           LOG_TRACE ("LTYPE.dashes[%d].text = %s [T 9]\n", j,


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free existing LTYPE dash entries, dash text, and strings_area before rebuilding dash data from DXF input. Also free a dash text string before replacing it inside the dash loop.

For commits considered too large, a request for a GNU copyright assignment covering PAST AND FUTURE CHANGES has been sent already.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (free_LTYPE_dashes): New helper.

* src/in_dxf.c (add_LTYPE_dashes): Free old dash data before replacement allocation and free dash text before assigning a new string.
