### PR TITLE
in_dxf: free LWPOLYLINE arrays before rebuilding vertices

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -402,6 +402,26 @@ free_GEODATA_geomesh_faces (Dwg_Object_GEODATA *restrict geodata)
   geodata->num_geomesh_faces = 0;
 }
 
+static void
+free_LWPOLYLINE_data (Dwg_Entity_LWPOLYLINE *restrict lwpolyline)
+{
+  if (!lwpolyline)
+    return;
+
+  free (lwpolyline->points);
+  lwpolyline->points = NULL;
+  lwpolyline->num_points = 0;
+  free (lwpolyline->bulges);
+  lwpolyline->bulges = NULL;
+  lwpolyline->num_bulges = 0;
+  free (lwpolyline->vertexids);
+  lwpolyline->vertexids = NULL;
+  lwpolyline->num_vertexids = 0;
+  free (lwpolyline->widths);
+  lwpolyline->widths = NULL;
+  lwpolyline->num_widths = 0;
+}
+
 /* With mips32 -O2 inline would fail. */
 static void
 dxf_skip_ws (Bit_Chain *dat)
@@ -2600,6 +2620,7 @@ new_LWPOLYLINE (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
   Dwg_Entity_LWPOLYLINE *o = obj->tio.entity->tio.LWPOLYLINE;
   int j = -1;
 
+  free_LWPOLYLINE_data (o);
   o->num_points = num_points;
   LOG_TRACE ("LWPOLYLINE.num_points = %u [BS 90]\n", num_points);
   o->points = (BITCODE_2RD *)xcalloc (num_points, sizeof (BITCODE_2RD));
@@ -2708,7 +2729,7 @@ new_LWPOLYLINE (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         }
       else if (pair->code == 91)
         {
-          if (!j)
+          if (!j && !o->vertexids)
             {
               o->vertexids
                   = (BITCODE_BL *)xcalloc (num_points, sizeof (BITCODE_BL));
@@ -2726,7 +2747,7 @@ new_LWPOLYLINE (Dwg_Object *restrict obj, Bit_Chain *restrict dat,
         }
       else if (pair->code == 40) // not const_width
         {
-          if (!j)
+          if (!j && !o->widths)
             {
               o->widths = (Dwg_LWPOLYLINE_width *)xcalloc (
                   num_points, sizeof (Dwg_LWPOLYLINE_width));


### PR DESCRIPTION
This is part of the DXF importer allocation-ownership cleanup found while reviewing Fuzzing Action LeakSanitizer reports.

Free existing LWPOLYLINE point, bulge, vertex-id, and width arrays before rebuilding vertex data from DXF input. Keep optional vertex-id and width arrays from being allocated again once present.

For commits considered too large, a request for a GNU copyright assignment covering PAST AND FUTURE CHANGES has been sent already.

This does not overlap the parsing or semantics scope of PR #1312-#1322.

* src/in_dxf.c (free_LWPOLYLINE_data): New helper.

* src/in_dxf.c (new_LWPOLYLINE): Free existing arrays before replacement and guard optional-array allocation.
