### PR TITLE
Fix stack overflow in dxf_CMC with overlong color book_name

### DIFF
--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -1271,7 +1271,10 @@ dxf_CMC (Bit_Chain *restrict dat, Dwg_Color *restrict color, const int dxf,
             {
               char *u8 = bit_convert_TU ((BITCODE_TU)color->book_name);
               if (u8)
-                strncpy (name, u8, 127);
+                {
+                  strncpy (name, u8, 127);
+                  name[127] = '\0';
+                }
               else
                 name[0] = '\0';
               free (u8);
@@ -1287,6 +1290,7 @@ dxf_CMC (Bit_Chain *restrict dat, Dwg_Color *restrict color, const int dxf,
           else
             {
               strncpy (name, color->book_name, 127);
+              name[127] = '\0';
               if (color->name)
                 {
                   strcat (name, "$");

--- a/src/out_dxfb.c
+++ b/src/out_dxfb.c
@@ -893,7 +893,10 @@ dxfb_CMC (Bit_Chain *restrict dat, Dwg_Color *restrict color, const int dxf,
             {
               char *u8 = bit_convert_TU ((BITCODE_TU)color->book_name);
               if (u8)
-                strncpy (name, u8, 127);
+                {
+                  strncpy (name, u8, 127);
+                  name[127] = '\0';
+                }
               else
                 name[0] = '\0';
               free (u8);
@@ -909,6 +912,7 @@ dxfb_CMC (Bit_Chain *restrict dat, Dwg_Color *restrict color, const int dxf,
           else
             {
               strncpy (name, color->book_name, 127);
+              name[127] = '\0';
               if (color->name)
                 {
                   strcat (name, "$");


### PR DESCRIPTION
A CMC color carries an optional book name that the DXF writers join with the color name into one group 430 value, using a 256 byte stack buffer sized for two 127 byte halves. The book name comes straight out of bit_read_T in bit_read_CMC and has no length cap in the file, so a book name of 127 bytes or more fills its half without leaving a terminator behind. The strcat that adds the separator then scans past index 127 through whatever the frame happened to hold, and the strncat after it starts from wherever that stopped, so up to 127 further bytes land past the end of name. I hit this converting an r2004 drawing whose colors carried 200 byte book and color names, where ASan reports the overread at out_dxf.c:1310 and out_dxfb.c:914 right before the write goes out of bounds. Terminating straight after the copy holds each half at 127 so the join fits exactly, which is what the other strncpy callers in the tree already do. Both the TU and the ASCII branch need it, and dxfb_CMC is the same code, so all four copies are covered.
