### PR TITLE
add_test: const-correct the version-string scanners (make check does not build on gcc 15)

### DIFF
--- a/test/unit-testing/add_test.c
+++ b/test/unit-testing/add_test.c
@@ -1284,7 +1284,7 @@ test_api_version (void)
 {
   const char *version = dwg_api_version_string ();
   long i0, i1, i2;
-  char *d0, *d1, *d2;
+  const char *d0, *d1, *d2;
   const int major = dwg_api_version_major ();
   const int minor = dwg_api_version_minor ();
 


### PR DESCRIPTION
On gcc 15 `make check` fails to **compile**, so the whole unit-test suite never runs:

```
add_test.c: In function ‘test_api_version’:
add_test.c:1296:6: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
 1296 |   d0 = strchr (version, '.');
add_test.c:1330:6: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
 1330 |   d0 = strchr (version, ':');
cc1: all warnings being treated as errors
make[4]: *** [Makefile:4692: add_test.o] Error 1
```

`test_api_version()` scans the `const char *` returned by `dwg_api_version_string()`
and `dwg_api_so_version()` but holds the `strchr()` results in plain `char *`. Since
the unit tests build with `-Werror`, this is fatal rather than a warning.

`d0`/`d1`/`d2` are only ever read from (`assert`, `&d0[1]`, `atoi`), so declaring them
`const char *` is enough — no cast and no copy.

**Verified** on 0.14.8556, Ubuntu with gcc 15.2.0: before the patch `make check` stops
at the compile error above; after it, **270 PASS / 0 FAIL**.

One line, test-only — the shipped library is unaffected.