### PR TITLE
INSERT: normalize has_attribs for pre-R13 (DXF 66 was written as 128)

### DIFF
--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -746,7 +746,7 @@ DWG_ENTITY (INSERT)
     FIELD_RD (rotation, 50);
   }
   VERSIONS (R_2_0b, R_11) {
-    DECODER { FIELD_VALUE (has_attribs) = R11FLAG (FLAG_R11_HAS_ATTRIBS); }
+    DECODER { FIELD_VALUE (has_attribs) = R11FLAG (FLAG_R11_HAS_ATTRIBS) ? 1 : 0; }
     FIELD_HANDLE (block_header, 2, 2);
     FIELD_2RD (ins_pt, 10)
 #ifndef IS_JSON


### PR DESCRIPTION
`dwg2dxf` writes an invalid DXF group 66 for every pre-R13 `INSERT` that has
attributes: the value is `128`, and group 66 admits only `0` or `1`.

The R11 decoder assigns the masked flag bits straight into the field:

```c
// src/dwg.spec:749
DECODER { FIELD_VALUE (has_attribs) = R11FLAG (FLAG_R11_HAS_ATTRIBS); }
```

`R11FLAG` is `(_ent->flag_r11 & (b))` (`src/spec.h:573`) and
`FLAG_R11_HAS_ATTRIBS` is `128` (`include/dwg.h:9106`), while `has_attribs` is
a `BITCODE_B` documented as DXF 66 (`include/dwg.h:4783`). So the masked bit
value reaches the DXF writer unchanged and is emitted verbatim.

The three sibling `POLYLINE` sites already normalize:

```
src/dwg.spec:1345   has_vertex = R11FLAG (FLAG_R11_HAS_ATTRIBS) ? 1 : 0;
src/dwg.spec:1431   has_vertex = R11FLAG (FLAG_R11_HAS_ATTRIBS) ? 1 : 0;
src/dwg.spec:2225   has_vertex = R11FLAG (FLAG_R11_HAS_ATTRIBS) ? 1 : 0;
```

Only the `INSERT` one at line 749 does not — which is exactly why `POLYLINE`
emits a correct `66 1` and `INSERT` emits `66 128` in the same file.

### The fix

```diff
-    DECODER { FIELD_VALUE (has_attribs) = R11FLAG (FLAG_R11_HAS_ATTRIBS); }
+    DECODER { FIELD_VALUE (has_attribs) = R11FLAG (FLAG_R11_HAS_ATTRIBS) ? 1 : 0; }
```

### Reproduce with the shipped test files

```sh
programs/dwg2dxf -o x.dxf programs/entities_r10.dwg
grep -A1 '^ 66$' x.dxf        # 128 before, 1 after
```

Affected: `programs/entities_r{2.6,2.10,10}.dwg` and
`test/test-data/r{2.6,2.10,9,10}/entities.dwg`.

### Why the DWG round-trip is not affected

`encode.c` does not copy the value back, it tests it and ORs the named
constant:

```c
// src/encode.c:5434
// Sync has_attribs -> flag_r11 HAS_ATTRIBS
if (_i->has_attribs)
  _ent->flag_r11 |= FLAG_R11_HAS_ATTRIBS;
```

So `has_attribs == 1` reconstructs `flag_r11` bit 128 identically to
`has_attribs == 128`. Every other reader of the field is also a truthiness
test (`if (FIELD_VALUE (has_attribs))`, `if (!_obj->has_attribs)`).

### Verification

- `dwg2dxf` output diff on each affected file is exactly `128` -> `1`. Nothing
  else changes.
- Regression sweep over all 146 DWGs in `test/test-data` and `programs/`,
  converted with a stock build and with this patch and then loaded with ezdxf
  1.4.4: no file changed except the group-66 value, none regressed.
- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged from the stock build.

Built and tested on Ubuntu 26.04, gcc 15.2.0, on top of `e405fcff`
(= tag `0.14.8556`).
