### PR TITLE
dxf: do not write R11 JUMP records into the ENTITIES section

### DIFF
--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -4056,6 +4056,14 @@ dxf_entities_write (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
           if (o->fixedtype == DWG_TYPE_BLOCK
               || o->fixedtype == DWG_TYPE_ENDBLK)
             continue;
+          // JUMP is not an entity but a "resume reading at this offset" marker
+          // of the R11 entity sections, and it carries no drawing data. DXF has
+          // no such record, and JUMP has no ownerhandle, so the branch below
+          // would emit it into mspace and break the POLYLINE-VERTEX-SEQEND
+          // sequence for conformant readers. decode.c already keeps JUMP out
+          // of the block header entity list for the same reason.
+          if (o->fixedtype == DWG_TYPE_JUMP)
+            continue;
           ohdl = o->tio.entity->ownerhandle;
           if (!ohdl || !ohdl->absolute_ref)
             {


### PR DESCRIPTION
`dwg2dxf` emits `0 JUMP` records into the DXF `ENTITIES` section for pre-R13
drawings. `JUMP` is not an entity — it is the "resume reading at this offset"
marker of the R11/R12 entity sections (`jump_address`, `jump_entity_section`),
and it carries no drawing data. DXF has no such record.

When a `JUMP` lands inside a polyline sequence the file stops being loadable.
ezdxf 1.4.4:

```
DXFStructureError: Expected DXF entity JUMP or SEQEND
```

Three of the shipped test files are affected, and all three are **completely
unreadable** by a conformant DXF reader today:

- `programs/entities_r10.dwg`
- `test/test-data/r10/entities.dwg`
- `test/test-data/r9/entities.dwg`

### Where it comes from

The pre-R13 branch of `dxf_entities_write` (`src/out_dxf.c:4043`) iterates all
objects in file order — it has to, because `SEQEND`/`VERTEX` are not in
`_hdr->entities[]`. It skips the structural markers `BLOCK` and `ENDBLK`, but
not `JUMP`. And since `JUMP` has no `ownerhandle`, it falls into the
"assume mspace" branch and gets written out:

```c
if (o->fixedtype == DWG_TYPE_BLOCK
    || o->fixedtype == DWG_TYPE_ENDBLK)
  continue;
ohdl = o->tio.entity->ownerhandle;
if (!ohdl || !ohdl->absolute_ref)
  {
    error |= dwg_dxf_object (dat, o, &i); // assume ms   <-- JUMP ends up here
    continue;
  }
```

`decode.c:7528` already excludes `DWG_TYPE_JUMP` when populating the block
header entity list, for exactly this reason — this change makes the DXF writer
agree with the decoder.

### The fix

Add `JUMP` to the skip list that already holds `BLOCK` and `ENDBLK`.

### Scope: why only this one place

- **BLOCKS writer** (`src/out_dxf.c:3914`) — unaffected. It requires
  `ohdl->absolute_ref == hdr_ref` and `continue`s on ownerless objects, so
  `JUMP` never reaches the writer.
- **Binary DXB** (`src/out_dxfb.c:2462`) — unaffected. It walks
  `get_first_owned_entity`/`get_next_owned_block_entity`, and that list never
  contains `JUMP` thanks to `decode.c:7528`. Verified empirically:
  `dwg2dxf -b` on `entities_r10.dwg` produces no `JUMP`.
- **R13+** — untouched by construction; the change is inside
  `if (dat->version < R_13b1)`.

### Reproduce with the shipped test files

```sh
programs/dwg2dxf -o x.dxf test/test-data/r10/entities.dwg
grep -c '^JUMP$' x.dxf     # 2 before, 0 after
python3 -c "import ezdxf; print(len(list(ezdxf.readfile('x.dxf').modelspace())))"
                           # DXFStructureError before, 20 after
```

### Verification

Regression sweep over all 146 DWGs in `test/test-data` and `programs/`, each
converted with a stock `0.14.8556` build and with this patch, then loaded with
ezdxf 1.4.4:

| | count |
|---|---:|
| files compared | 146 |
| byte-identical output | 143 |
| **fixed** (unreadable -> loads) | **3** |
| **regressed** | **0** |
| entities recovered | +60 |

`make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged from the stock build.

Built and tested on Ubuntu 26.04, gcc 15.2.0, on top of `e405fcff`
(= tag `0.14.8556`).

---

### Related, not fixed here

`REPEAT`, `ENDREP` and `LOAD` also reach the DXF `ENTITIES` section and are
likewise not DXF entities. Unlike `JUMP` they carry data, so representing them
is a design decision rather than a filter — filed separately.
