### PR TITLE
decode: r2004 sections whose declared size exceeds the page estimate (fixes #1294)

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -2061,6 +2061,22 @@ read_2004_compressed_section (Bit_Chain *dat, Dwg_Data *restrict dwg,
   {
     uint64_t max_decomp_size64
         = (uint64_t)info->num_sections * (uint64_t)info->max_decomp_size;
+    /* num_sections * max_decomp_size is only an upper-bound *estimate* of the
+       decompressed section. Each page carries its own StartOffset into the
+       buffer, so what the buffer really has to span is info->size, the declared
+       decompressed total. On some r2018 files the estimate comes out 1-3 pages
+       short of info->size; rejecting those loses the whole drawing
+       (num_objects: 0) even though every page is fine. Allocate whichever is
+       larger and keep the sanity cap. */
+    if (info->size > 0 && (uint64_t)info->size > max_decomp_size64)
+      {
+        LOG_TRACE ("Section %s: declared size %" PRId64 " exceeds the %"
+                   PRIu64 " estimate (" FORMAT_RL " * " FORMAT_RL
+                   "), allocating the declared size\n",
+                   info->name, info->size, max_decomp_size64,
+                   info->num_sections, info->max_decomp_size);
+        max_decomp_size64 = (uint64_t)info->size;
+      }
     if (max_decomp_size64 == 0 || max_decomp_size64 > 0x2f000000) // 790Mb
       {
         LOG_ERROR ("Invalid section %s count or max decompression size. "
@@ -2070,12 +2086,9 @@ read_2004_compressed_section (Bit_Chain *dat, Dwg_Data *restrict dwg,
       }
     max_decomp_size = (uint32_t)max_decomp_size64;
   }
-  if (info->size > (int64_t)info->num_sections * (int64_t)info->max_decomp_size
-      || info->size < 0)
+  if (info->size < 0)
     {
-      LOG_ERROR ("Invalid section %s size %" PRId64 " > %u * " FORMAT_RL,
-                 info->name, info->size, info->num_sections,
-                 info->max_decomp_size);
+      LOG_ERROR ("Invalid section %s size %" PRId64, info->name, info->size);
       return DWG_ERR_VALUEOUTOFBOUNDS;
     }
   LOG_HANDLE ("Alloc section %s size %" PRIu32 "\n", info->name,
@@ -2164,9 +2177,19 @@ read_2004_compressed_section (Bit_Chain *dat, Dwg_Data *restrict dwg,
       LOG_INSANE ("bytes_left:               %ld\n", bytes_left);
 
       // check if compressed at all
+      /* Bound the page by what it actually decompresses to, not by the
+         section-wide maximum: the last page is normally shorter, so
+         address + max_decomp_size overshoots the buffer while
+         address + page_size fits. When that happens for a *compressed*
+         section, control falls into the else branch below, which rejects it
+         outright on `info->compressed == 2` and loses the whole section. The
+         else branch already computes the real size this way. */
       if (info->compressed == 2 && bytes_left > 0
           && es.fields.address <= max_decomp_size
-          && es.fields.address + info->max_decomp_size <= max_decomp_size)
+          && es.fields.address
+                     + MIN ((BITCODE_RL)(info->size - es.fields.address),
+                            es.fields.page_size)
+                 <= max_decomp_size)
         {
           size_t orig_size = dat->size;
           dec.byte = es.fields.address;


### PR DESCRIPTION
Fixes #1294.

Two AC1032 files here decoded to `num_objects: 0` with

```
ERROR: Invalid section AcDb:AcDbObjects size 4678786 > 156 * 29696
ERROR: Failed to read compressed AcDbObjects section
```

although every page in the section is fine — ODA File Converter and BricsCAD
read the same drawings completely. A 1 MB public reproducer is attached to
#1294.

## First layer: the buffer is sized from an estimate

`num_sections * max_decomp_size` is an upper-bound *estimate*. Each page carries
its own `StartOffset` into the decompressed buffer, so what the buffer actually
has to span is `info->size`, the declared decompressed total. On these files the
estimate lands **1 to 3 pages short** of `info->size`, and the whole drawing is
refused rather than the buffer being grown:

| file | `info->size` | `num_sections` × 29696 | short by | pages |
|---|---:|---:|---:|---:|
| #1294's (not attached) | 9 918 156 | 9 888 768 | 29 388 | 0.99 |
| `cerco-perimetrico` | 4 678 786 | 4 632 576 | 46 210 | 1.56 |
| `planos-constructivos-A` | 13 535 788 | 13 511 680 | 24 108 | 0.81 |
| `planos-constructivos-B` | 22 261 264 | 22 182 912 | 78 352 | 2.64 |
| a file that passes | 80 910 | 89 088 | — | −0.28 |

Now whichever of the two is larger gets allocated. The 790 MB cap and the
64-bit overflow guard right above it are untouched, and `info->size < 0` is
still rejected.

## Second layer: the per-page guard uses the wrong size

This is what actually loses the section. The guard deciding whether a page fits
compares against the section-wide maximum instead of that page's own
decompressed size:

```c
if (info->compressed == 2 && bytes_left > 0
    && es.fields.address <= max_decomp_size
    && es.fields.address + info->max_decomp_size <= max_decomp_size)
```

The last page of a section is normally shorter, so `address + max_decomp_size`
overshoots the buffer while `address + page_size` fits comfortably. And when
that guard fails for a **compressed** section, control falls into the `else`
branch, whose very first condition is `info->compressed == 2` — so it returns
`"Some section size or address out of bounds"` and **156 good pages are thrown
away because of the last one**.

The `else` branch already computes the real size, eight lines below:

```c
const BITCODE_RL size = MIN ((BITCODE_RL)(info->size - es.fields.address),
                             es.fields.page_size);
```

The guard now uses the same expression, so both paths agree.

This also explains why only *some* r2018 files fail. When the page estimate is
generous there is slack and the guard passes by luck; when the pages are nearly
full there is none, and the final page kills the section every time. Which fits
the table above: the failures overshoot by under three pages, the file that
passes sits comfortably below.

It also argues against the deleted-objects theory from the issue thread:
`cerco-perimetrico` has `HANDSEED` `0x1313` = 4883 against ~2222 live entities,
a 2.2× ratio — an ordinary handle history — and it still failed.

## Verification

Against ODA File Converter 25.6, modelspace entities, same drawings:

| drawing | before | after | ODA |
|---|---:|---:|---:|
| `cerco-perimetrico.dwg` | **0** | **2222** | 2222 |
| `planos-constructivos-A.dwg` | **0** | **26583** | 26583 |
| `planos-constructivos-B.dwg` | **0** | **26583** | 26583 |
| control (passes the size check) | 1108 | 1108 | — |

Exact matches, entity for entity.

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, identical to the unpatched build.
- All **146** DWGs in `test/test-data` and `programs/` re-converted with and
  without the patch: **143 byte-identical, 0 worse**. (The 3 that differ are the
  `JUMP` fix in #1353, which the same build tree carries.)
- A 190-drawing corpus sweep, stock vs patched: **OK 160 → 166, 0 regressions**.

Built and tested on Ubuntu 26.04, gcc 15.2.0, on top of `e405fcff`
(= tag `0.14.8556`), ezdxf 1.4.4 and ODA File Converter 25.6 for the reference
side.

Happy to run any variation against the three files if you would rather bound the
page differently — @SimonSAMPERE can test his own file too, which the attached
reproducer does not replace.
