### PR TITLE
dwg: skip unresolvable owned entities instead of ending the layout (fixes #1357)

### DIFF
--- a/src/dwg.c
+++ b/src/dwg.c
@@ -1233,18 +1233,25 @@ get_first_owned_entity (const Dwg_Object *hdr)
     }
   else if (version >= R_2004 || version < R_13b1)
     {
-      _hdr->__iterator = 0;
-      if (_hdr->entities && _hdr->num_owned && _hdr->entities[0])
+      /* Skip entries that do not resolve rather than reporting the layout as
+         empty: NULL is the caller's end-of-list signal, so one dangling
+         reference at the head would hide every entity behind it. */
+      Dwg_Data *dwg = hdr->parent;
+      for (_hdr->__iterator = 0;
+           _hdr->entities && _hdr->__iterator < _hdr->num_owned;
+           _hdr->__iterator++)
         {
-          Dwg_Data *dwg = hdr->parent;
-          Dwg_Object *obj = dwg_ref_object (dwg, _hdr->entities[0]);
+          Dwg_Object_Ref *ref = _hdr->entities[_hdr->__iterator];
+          Dwg_Object *obj = ref ? dwg_ref_object (dwg, ref) : NULL;
           if (version < R_13b1 && obj && obj->fixedtype == DWG_TYPE_JUMP)
-            return dwg_resolve_jump (obj);
-          else
+            obj = dwg_resolve_jump (obj);
+          if (obj)
             return obj;
+          LOG_WARN ("Skip unresolvable entity " FORMAT_BL " of " FORMAT_BL
+                    " in BLOCK_HEADER " FORMAT_HV,
+                    _hdr->__iterator, _hdr->num_owned, hdr->handle.value);
         }
-      else
-        return NULL;
+      return NULL;
     }
 
   // TODO: preR13 block table
@@ -1352,15 +1359,24 @@ get_next_owned_entity (const Dwg_Object *restrict hdr,
     {
       Dwg_Object *obj;
       Dwg_Object_Ref *ref;
-      _hdr->__iterator++;
-      if (_hdr->__iterator == _hdr->num_owned)
-        return NULL;
-      ref = _hdr->entities ? _hdr->entities[_hdr->__iterator] : NULL;
-      obj = ref ? dwg_ref_object (dwg, ref) : NULL;
-      if (version < R_13b1 && obj && obj->fixedtype == DWG_TYPE_JUMP)
-        return dwg_resolve_jump (obj);
-      else
-        return obj;
+      /* See get_next_owned_block_entity: NULL is the caller's end-of-list
+         signal, so a dangling reference must be skipped, not reported as the
+         end. dwggrep and dwg2SVG walk this one. */
+      while (1)
+        {
+          _hdr->__iterator++;
+          if (_hdr->__iterator >= _hdr->num_owned)
+            return NULL;
+          ref = _hdr->entities ? _hdr->entities[_hdr->__iterator] : NULL;
+          obj = ref ? dwg_ref_object (dwg, ref) : NULL;
+          if (version < R_13b1 && obj && obj->fixedtype == DWG_TYPE_JUMP)
+            obj = dwg_resolve_jump (obj);
+          if (obj)
+            return obj;
+          LOG_WARN ("Skip unresolvable entity " FORMAT_BL " of " FORMAT_BL
+                    " in BLOCK_HEADER " FORMAT_HV,
+                    _hdr->__iterator, _hdr->num_owned, hdr->handle.value);
+        }
     }
 
   LOG_ERROR ("Unsupported version %s\n", dwg_version_type (version));
@@ -1612,15 +1628,27 @@ get_next_owned_block_entity (const Dwg_Object *restrict hdr,
     {
       Dwg_Object *obj;
       Dwg_Object_Ref *ref;
-      _hdr->__iterator++;
-      if (_hdr->__iterator == _hdr->num_owned)
-        return NULL;
-      ref = _hdr->entities ? _hdr->entities[_hdr->__iterator] : NULL;
-      obj = ref ? dwg_ref_object (dwg, ref) : NULL;
-      if (version < R_13b1 && obj && obj->fixedtype == DWG_TYPE_JUMP)
-        return dwg_resolve_jump (obj);
-      else
-        return obj;
+      /* Keep advancing over entries that do not resolve. NULL is the caller's
+         end-of-list signal (out_dxf.c and out_dxfb.c walk this with
+         `while (obj)`), so returning it for a dangling reference abandons every
+         entity after it: one bad reference at index 93 of 10847 cost a whole
+         drawing. Skipping loses one entity, stopping loses all the rest. `>=`
+         rather than `==` so a bumped iterator cannot walk off the end. */
+      while (1)
+        {
+          _hdr->__iterator++;
+          if (_hdr->__iterator >= _hdr->num_owned)
+            return NULL;
+          ref = _hdr->entities ? _hdr->entities[_hdr->__iterator] : NULL;
+          obj = ref ? dwg_ref_object (dwg, ref) : NULL;
+          if (version < R_13b1 && obj && obj->fixedtype == DWG_TYPE_JUMP)
+            obj = dwg_resolve_jump (obj);
+          if (obj)
+            return obj;
+          LOG_WARN ("Skip unresolvable entity " FORMAT_BL " of " FORMAT_BL
+                    " in BLOCK_HEADER " FORMAT_HV,
+                    _hdr->__iterator, _hdr->num_owned, hdr->handle.value);
+        }
     }
 
   LOG_ERROR ("Unsupported version %s\n", dwg_version_type (version));


### PR DESCRIPTION
Fixes #1357.

`get_next_owned_block_entity` returns `NULL` both for "the list is over" and for
"this entry does not resolve", and `out_dxf.c:4093` / `out_dxfb.c:2464` walk it
with `while (obj)`. So one dangling reference ends the whole layout and every
entity behind it is dropped — silently, with exit status 0.

## Measured on a real drawing

An R2007 file here, ordinary survey content (contour lines, text, polylines,
0 unknown objects):

```
*Model_Space entities[]                      10847 references
references pointing at objects that
  failed to decode                            2258
index of the FIRST broken reference             93
entities dwg2dxf wrote to ENTITIES              93   <-- gives up exactly there
```

Skipping the broken entries instead takes it to **8588** — the 10847 minus the
2258 that genuinely cannot be resolved, i.e. everything recoverable. ODA File
Converter 25.6 reads the same DWG into 10847; those 2258 objects are a decoder
problem of their own (that file logs ~2000 `Invalid class index` errors) and not
this issue.

## Three functions had it, not one

| function | walked by |
|---|---|
| `get_first_owned_entity` | `entities[0]` not resolving reported the layout as **empty from the start** |
| `get_next_owned_entity` | **`dwggrep`** and **`dwg2SVG`** |
| `get_next_owned_block_entity` | `out_dxf.c` and `out_dxfb.c` |

## Block layouts were where most of the loss hid

Two more drawings from the same corpus had complete modelspaces, so nothing
looked wrong until the `BLOCKS` section was counted too:

| drawing | entities written before | after | decoded |
|---|---:|---:|---:|
| `yanaquihua.dwg` | 79 311 | **126 500** | 126 503 |
| `cofopri.dwg` | 9 076 | **78 241** | 78 244 |

47 000 and 69 000 entities respectively, recovered from block definitions that
were being cut short at their first dangling reference.

## Also

- `>=` rather than `==` against `num_owned`: with `==`, an iterator that gets
  bumped past the count never terminates and walks off the end of `entities[]`.
- Each skipped reference logs a warning, so the loss is visible instead of
  silent.

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged from the unpatched
  build.
- All **146** DWGs in `test/test-data` and `programs/` re-converted before and
  after: **146 identical, 0 worse**. The change only takes effect where a
  reference does not resolve, and upstream's test files have none.

Built and tested on Ubuntu 26.04, gcc 15.2.0, on top of `e405fcff`
(= tag `0.14.8556`), ezdxf 1.4.4 and ODA File Converter 25.6 for the reference
side.

Independent of #1358 (r2004 section sizing) — they touch different files and
either can go in alone.
