### PR TITLE
decode: resync the object map when a modular char fails to parse (fixes the data loss in #1355)

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -2592,11 +2592,22 @@ read_2004_section_handles (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
                               " looks wrong, should be prevsize " FORMAT_MC
                               " + 4",
                               offset, prevsize - 4);
-                  // handleoff = 1;
-                  // offset = prevsize;
-                  // LOG_WARN ("Recover invalid handleoff to %" PRIuSIZE " and
-                  // offset to %ld",
-                  //           handleoff, offset);
+                }
+              /* Resynchronise when the modular char itself failed to parse
+                 (bit_read_UMC returns 0 on error). Trusting those bytes
+                 fabricates an object at an impossible address and derails every
+                 entry after it; retrying one byte later recovers the rest of the
+                 page.
+
+                 Only on !handleoff. The other two conditions above are
+                 heuristics that also fire on entries which parsed fine, and
+                 those are better used than skipped -- resyncing on them costs
+                 good entries (test-data/2004/Leader.dwg loses all 10). */
+              if (!handleoff && oldpos + 1 < startpos + (size_t)section_size)
+                {
+                  hdl_dat.byte = oldpos + 1;
+                  hdl_dat.bit = 0;
+                  continue;
                 }
             }
           last_offset += offset;


### PR DESCRIPTION
Fixes the data loss in #1355. **It also corrects the root cause I posted in that
thread** — my earlier analysis there was wrong, details below.

The attached `frontal.dwg` in #1355 decoded 1108 of its objects and then produced
a DXF cut off inside `TABLES`, with no `ENTITIES` section and no `EOF`, after 4060
errors starting with

```
ERROR: bit_read_UMC: error parsing modular char, i=-1,j=56,result=0x3FFFFFFFFFB81
  @2175.0: [0xff 0xff 0xff 0xff 0xff 0x81]
Warning: Ignore invalid handleoff (@2173)
Object number: 1040, Size: 4202513 [MS]        <- 4.2 MB in a 61 KB file
```

## Correction first

Earlier in #1355 I claimed the object map needed 3103 bytes while
`AcDb:Handles` declared `size: 0xA20` = 2592, i.e. that a third page did not fit
and the section was 511 bytes short. **That was wrong.** The "third page" was an
artefact of the misparse below. Please disregard those numbers; nobody should go
looking for a section-sizing problem here.

## What the file actually contains

Dumping `hdl_dat` and walking the pages by hand with `bit_calc_CRC`:

```
page 1 @0     size 2033   CRC 11BD valid   975 entries, filling it exactly
page 2 @2035  size  551   CRC 060E valid   195 entries
@2588         size    2                    terminator — the map ends here
```

So the section is **not** short, there is no third page, and
`hdl_dat.size = 2592` is right: the map ends cleanly at 2588 with 4 bytes of
padding. Both pages' CRCs validate, so their content is genuine.

What page 2 does hold, 138 bytes in, is two bytes that are not part of the
`(UMC, MC)` entry stream:

```
... 01 35 01 35 01 3f | 81 f7 | ff ff ff ff ff 81 8d 01 f2 b8 44 01 30 ...
    \_ normal pairs _/  \_ 2 _/  \_ normal pairs resume _/
```

`bit_read_UMC` hits nine consecutive bytes with the high bit set — a modular char
cannot exceed eight — and returns 0. The loop then warns and **uses the garbage
anyway**, which is what fabricates the 4.2 MB object and derails everything after
it.

## The fix

Retry one byte later instead of trusting the failed read.

Walking page 2 that way decodes all **195** entries, skips exactly **2** bytes,
and ends exactly on the page boundary at 2586. That exactness is the
self-check: a wrong alignment would drift and miss the CRC position entirely.

**Only on `!handleoff`.** The other two conditions in the same `if` are
heuristics that also fire on entries which parsed fine, and those are better used
than skipped — resyncing on them costs good entries, and
`test-data/2004/Leader.dwg` loses all 10 of its modelspace entities. I had that
wrong in a first attempt and the regression sweep caught it.

## Result

| | before | after |
|---|---:|---:|
| objects decoded | 1108 | **1170** |
| errors | 4060 | **2** |
| table control objects | 2 | **9** |
| `*Model_Space` BLOCK_HEADER | absent | **present** |
| DXF group-code pairs | 641 | **18612**, ending in `EOF` |
| modelspace entities | 0 | **1039** |

The 9 controls are `APPID BLOCK DIMSTYLE LAYER LTYPE STYLE UCS VIEW VPORT` — the
missing ones were exactly why the DXF writer died right after the `VPORT` table.

ODA File Converter 25.6 reads the same drawing into 1039 modelspace `LINE`s on
the same four layers (`0`, `PROFILEEDGES`, `SECTIONCUTEDGES`, `Defpoints`), so
this is an exact match.

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged.
- All **146** DWGs in `test/test-data` and `programs/` re-converted before and
  after: **146 identical, 0 worse**.
- A 190-drawing corpus sweep: the one drawing changes `EMPTY` → `OK` with 1039
  entities, **0 regressions**.

Built and tested on Ubuntu 26.04, gcc 15.2.0, on top of `e405fcff`
(= tag `0.14.8556`), ezdxf 1.4.4 and ODA File Converter 25.6 for the reference
side.

## What this does not fix

The exit-status half of #1355 still stands: a write that stops before `ENTITIES`
and never emits `EOF` should be reported, whatever the policy for non-critical
decode errors. This change removes the cause for that file, not the silence.

Touches `decode.c` like #1358 but in a different function, so they only need a
trivial merge; either can go in alone.
