### PR TITLE
decode: widen the pre-R13 sentinel search to the +-1000 it documents

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -6772,9 +6772,14 @@ decode_preR13_sentinel (const Dwg_Sentinel sentinel,
   LOG_TRACE_TF (r11_sentinel, 16);
   if (memcmp (r11_sentinel, wanted, 16))
     {
-      size_t pos = MAX (dat->byte, 200) - 200;
-      size_t len = MIN (dat->size - dat->byte, 400);
-      // search +- 1000 bytes around
+      /* Search +- 1000 bytes around, as the comment always said. It was
+         actually +-200 (pos = byte - 200, len = 400), which misses real files:
+         a r11 drawing here has every table sentinel displaced from where the
+         header's table address puts it, LAYER_BEGIN by -300 and VIEW_BEGIN by
+         -608, so this recovery never fired and the whole file was rejected. */
+      const size_t window = 1000;
+      size_t pos = dat->byte > window ? dat->byte - window : 0;
+      size_t len = MIN (dat->size - pos, 2 * window);
       char *found = (char *)memmem (&dat->chain[pos], len, wanted, 16);
       if (!found)
         {


### PR DESCRIPTION
A r11 drawing here was rejected outright:

```
ERROR: DWG_SENTINEL_R11_LAYER_BEGIN not found at 67586
ERROR: Failed to decode file .../segundo-piso.dwg 0x101
READ ERROR 0x101
```

The file is not corrupt. The sentinel is there — 300 bytes earlier than where the
header's table address puts it. In fact **every** table sentinel in that drawing
sits earlier than expected:

| sentinel | expected at | actually at | off by |
|---|---:|---:|---:|
| `BLOCK_BEGIN` | 67286 | 67254 | −32 |
| `LAYER_BEGIN` | 67586 | 67286 | **−300** |
| `STYLE_BEGIN` | 67741 | 67586 | −155 |
| `VIEW_BEGIN` | 67971 | 67363 | **−608** |

## `decode_preR13_sentinel` already recovers from this

When the sentinel is not where expected it searches around, repositions, and
carries on with a `WRONGCRC` warning. The window, though:

```c
size_t pos = MAX (dat->byte, 200) - 200;
size_t len = MIN (dat->size - dat->byte, 400);
// search +- 1000 bytes around
```

±200, while the comment right underneath promises ±1000. `LAYER_BEGIN` at −300
fell outside by 116 bytes, so the recovery never fired and the whole file was
lost to `SECTIONNOTFOUND`.

This widens it to the documented ±1000 and computes `len` from `pos`, so the
window really covers both directions (as written, `len` was measured from
`dat->byte` while the search started 200 bytes earlier).

## Result

Two r11 drawings that produced no output at all now decode to exactly what ODA
File Converter reads from them:

| drawing | before | after | ODA |
|---|---|---:|---:|
| `primer-piso.dwg` | no output | **1246** | 1246 |
| `segundo-piso.dwg` | no output | **1459** | 1459 |

The recovery reports each displacement, so the oddity stays visible:

```
Warning: DWG_SENTINEL_R11_LAYER_BEGIN not found at 67586, but at 67286
```

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged.
- All **146** DWGs in `test/test-data` and `programs/` re-converted before and
  after: **146 identical, 0 worse**. Upstream's own r11 files have their
  sentinels where the header says, so none of them takes this path.
- A 190-drawing corpus sweep: `NO_OUTPUT` 3 → 1, `OK` 167 → 169, **0
  regressions**.

I did not chase *why* the addresses are off by a varying amount in that file —
the recovery path exists precisely so that does not have to be understood
file by file, and it was only failing because it looked in a smaller window than
it advertised. Happy to dig further if you would rather fix the address
computation instead.

Built and tested on Ubuntu 26.04, gcc 15.2.0, on top of `e405fcff`
(= tag `0.14.8556`), ODA File Converter 25.6 for the reference side. The two
drawings are shareable if you want them — 69 KB each.
