### PR TITLE
decode_r2007: Reed-Solomon decode uncompressed data pages too

### DIFF
--- a/src/decode_r2007.c
+++ b/src/decode_r2007.c
@@ -682,6 +682,20 @@ read_system_page (Bit_Chain *out, Bit_Chain *dat, int64_t size_comp,
   return true;
 }
 
+/* Size on disk of a Reed-Solomon coded data page holding size_comp payload
+   bytes: RS works on 0xFB-byte blocks expanded to 0xFF, and the page is then
+   padded to a multiple of 32.  A page whose size matches this exactly is RS
+   coded; a page stored verbatim is only padded to 32 and comes out smaller.
+   The section page record has no flag for it (unlike r2004+), so the size is
+   the only thing to go by.  */
+static int64_t
+page_size_if_rs_coded (const int64_t size_comp)
+{
+  const int64_t pesize = (size_comp + 7) & ~7;
+  const int64_t block_count = (pesize + 0xFB - 1) / 0xFB;
+  return (block_count * 0xFF + 31) & ~31;
+}
+
 static int
 read_data_page (Bit_Chain *restrict dat, BITCODE_RC *restrict decomp,
                 int64_t page_size, int64_t size_comp, int64_t size_uncomp,
@@ -830,9 +844,16 @@ read_data_section (Bit_Chain *sec_dat, Bit_Chain *dat,
           return DWG_ERR_VALUEOUTOFBOUNDS;
         }
       dat->byte = page->offset;
-      // only if compressed. TODO: Isn't there a compressed flag as with 2004+?
-      // theoretically the sizes could still be the same.
-      if (section_page->comp_size != section_page->uncomp_size)
+      /* Reed-Solomon coding is independent of compression: read_data_page()
+         undoes the RS coding first and only then decompresses, when
+         comp_size < uncomp_size.  An uncompressed page can therefore still be
+         RS coded, and copying it straight out of dat->chain hands the caller
+         the RS codewords -- payload interleaved with parity.  Take the RS path
+         whenever the page on disk is exactly as large as the RS coded form of
+         its payload; page->size is the only evidence available. */
+      if (section_page->comp_size != section_page->uncomp_size
+          || (int64_t)page->size
+                 == page_size_if_rs_coded (section_page->comp_size))
         {
           error = read_data_page (dat, &decomp[section_page->offset],
                                   page->size, section_page->comp_size,
@@ -840,7 +861,7 @@ read_data_section (Bit_Chain *sec_dat, Bit_Chain *dat,
           if (error)
             {
               free (decomp);
-              LOG_ERROR ("Failed to read compressed page");
+              LOG_ERROR ("Failed to read page");
               return error;
             }
         }


### PR DESCRIPTION
`read_data_section()` reads "not compressed" as "not encoded", and copies such a
page straight out of the file buffer:

```c
      dat->byte = page->offset;
      // only if compressed. TODO: Isn't there a compressed flag as with 2004+?
      // theoretically the sizes could still be the same.
      if (section_page->comp_size != section_page->uncomp_size)
        {
          error = read_data_page (dat, &decomp[section_page->offset], ...);
        }
      else
        {
          ...
          memcpy (&decomp[section_page->offset], &dat->chain[dat->byte],
                  section_page->uncomp_size);
        }
```

Reed-Solomon coding, though, is independent of compression — and
`read_data_page()` already treats the two separately: it undoes the RS coding
first, and only then decompresses, `if (size_comp < size_uncomp)`. So an
uncompressed page can still be RS coded, and that `memcpy` hands the caller the
RS codewords: payload interleaved with parity.

## How the file shows it

An 11 MB r2007 drawing here has `AcDb:AcDbObjects` in 181 pages, **136 of them
stored uncompressed**. Splitting its object map by page kind:

| pages | objects | fail | |
|---|---:|---:|---:|
| compressed (45) | 10586 | 0 | 0.0% |
| uncompressed (136) | 2259 | 2183 | **96.6%** |

Not one object in a compressed page failed; almost none in an uncompressed page
survived. The failures are the usual symptoms of reading from the wrong bytes —
`Invalid object type 37521, only 65 classes`, `Invalid class index -500 < 0`,
`Invalid bitsize 1866445698 > 243880`. Shannon entropy of the affected byte
ranges is **7.87** bits/byte against **6.39** in the intact ones, which is what
parity interleaved with data looks like.

The 2183 lost objects are **2232 LWPOLYLINEs** plus a handful of
CIRCLE/MTEXT/TEXT/LINE, and their handles are still listed in `*Model_Space`'s
entity array, so they surface downstream as 2258 references that resolve to
nothing.

## Telling the two page kinds apart

The section page record has no compression flag — that is exactly what the TODO
in the comment asks about — so `page->size` is the only evidence. An RS coded
page is `ceil(comp_size / 0xFB) * 0xFF` rounded up to 32; a verbatim page is
only rounded up to 32, and comes out smaller. Over all 192 pages of that file:

| | pages | `page->size == RS size` |
|---|---:|---|
| compressed | 51 | yes, all |
| uncompressed | 137 | yes, all |
| uncompressed | 4 | no — `SummaryInfo`, `Preview`, `AppInfo`, `FileDepList` |

Those last four really are verbatim: read that way they give
`LASTSAVEDBY: "Nestor"`, `appinfo_name: "AppInfoDataList"`, `version:
"17.0.54.0"`, sane `TDCREATE`/`TDUPDATE`. So the patch takes the RS path only
when `page->size` matches the coded size exactly, and anything else keeps
today's verbatim copy. Compressed pages are untouched either way.

If you know the real discriminator I would rather use it than a size match — but
the size match is a necessary condition, not a guess: a page too small to hold
the codewords cannot be RS coded.

## Result

Against ODA File Converter 25.6 on that drawing:

| | before | after | ODA |
|---|---:|---:|---:|
| modelspace entities | 8588 | **10847** | 10847 |
| `LWPOLYLINE` vertices | 231138 | **1026048** | 1026048 |
| vertices near `DBL_MAX` | 33188 | **0** | 0 |
| coordinates above 1e12 | 45316 | **0** | 40 |

**This also closes #1361**, which I filed for `LWPOLYLINE` point arrays
"desynchronising mid-list". They were not desynchronising — they were being read
out of RS codewords. Sorry for the misdirection there; I will note it in the
issue.

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged. That includes the two
  unit tests over this area, `decompress_r2007` and `read_data_section: rejects
  out-of-bounds page->offset`; both still pass.
- All **146** DWGs in `test/test-data` and `programs/` converted before and
  after: **146 byte-identical, 0 worse**. None of them stores a data page
  uncompressed, so none takes the new path.
- `decode_R2007` is reached only for `R_2007a..R_2007` — r2010+ goes through
  `decode_R2004` — so the blast radius is exactly AC1021 files. **All 47 AC1021
  drawings in a 1657-file corpus**, both builds, same measure:

  | | before | after |
  |---|---:|---:|
  | entities total | 639053 | **667767** (+28714) |
  | drawings gaining | — | 6 |
  | drawings losing | — | **0** |
  | unchanged | — | 41 |

  Three of the six go `LOAD_FAIL -> OK` (+11550, +10847, +5725); the other three
  gain 182–207 entities each.

Built on Ubuntu 26.04, gcc 15.2.0, at `e405fcff` (= tag `0.14.8556`). The
reproducers are already attached to #1356
([handle-collision-dwgs.zip](https://github.com/tuxiasumari/libredwg/releases/download/bugfiles-2026-08-06/handle-collision-dwgs.zip));
`sedapar.dwg` is the 11 MB one, `cofopri.dwg` shows it too.
