### PR TITLE
decode_r11: a missing table sentinel must not reject the drawing (fixes #767)

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -6783,8 +6783,12 @@ decode_preR13_sentinel (const Dwg_Sentinel sentinel,
       char *found = (char *)memmem (&dat->chain[pos], len, wanted, 16);
       if (!found)
         {
-          LOG_ERROR ("%s not found at %" PRIuSIZE, sentinel_name,
-                     dat->byte - 16);
+          /* A warning, not an error: whether a missing sentinel is fatal is
+             the caller's call -- the table reader in decode_r11.c carries on
+             from the header's own table address -- and a caller that does
+             give up still reports it through "Failed to decode file". */
+          LOG_WARN ("%s not found at %" PRIuSIZE, sentinel_name,
+                    dat->byte - 16);
           error = DWG_ERR_SECTIONNOTFOUND;
         }
       else

--- a/src/decode_r11.c
+++ b/src/decode_r11.c
@@ -273,10 +273,30 @@ decode_preR13_section (Dwg_Section_Type_r11 id, Bit_Chain *restrict dat,
 
   SINCE (R_11)
   {
+/* A missing table delimiter is not worth the drawing. The records are found
+   through tbl->address, which the header states independently of the
+   sentinel, and every pre-R13 table record carries its own CRC, checked
+   below -- so a wrong address is caught on its own merits rather than
+   guessed at from the delimiter. Rejecting the file instead threw away the
+   ENTITIES section that had already decoded: r11 writers exist that omit the
+   sentinels of the empty VIEW/UCS/VPORT tables (all three sharing one
+   address) and of the table that follows them (GH #767).
+   DWG_ERR_INVALIDDWG is left fatal on purpose: that one means the 16 bytes
+   could not even be read, so the position itself is nonsense. */
 #define DECODE_PRER13_SENTINEL(ID)                                            \
-  error |= decode_preR13_sentinel (ID, #ID, dat, dwg);                        \
-  if (error >= DWG_ERR_SECTIONNOTFOUND)                                       \
-  return error
+  {                                                                           \
+    int _sentinel_err = decode_preR13_sentinel (ID, #ID, dat, dwg);           \
+    if (_sentinel_err == DWG_ERR_SECTIONNOTFOUND)                             \
+      {                                                                       \
+        LOG_WARN ("%s missing, reading table %s at its header address "        \
+                  "0x%zx anyway",                                             \
+                  #ID, tbl->name, (size_t)tbl->address);                      \
+        _sentinel_err = DWG_ERR_WRONGCRC;                                     \
+      }                                                                       \
+    else if (_sentinel_err >= DWG_ERR_SECTIONNOTFOUND)                        \
+      return error | _sentinel_err;                                           \
+    error |= _sentinel_err;                                                   \
+  }
 
     switch (id)
       {


### PR DESCRIPTION
Fixes #767, open since 2023-06. Reproducer: the file attached to that issue.

```
ERROR: DWG_SENTINEL_R11_VIEW_BEGIN not found at 34056
ERROR: Failed to decode file ... 0x100
```

By the time that fires, the ENTITIES section has already decoded — all 553
entities of it — along with BLOCK, LAYER, STYLE and LTYPE. All of it is thrown
away over the delimiter of a table with **zero rows**.

## What is actually missing from that file

Scanning it for all 22 r11 sentinel constants, six are simply absent:

| sentinel | in the file |
|---|---|
| `VIEW_BEGIN`, `VIEW_END` | **no** |
| `UCS_BEGIN`, `UCS_END` | **no** |
| `VPORT_BEGIN` | **no** |
| `VPORT_END` | yes, at `0x8518` |
| `APPID_BEGIN` | **no** |
| `APPID_END` | yes, at `0x854D` |
| `BLOCK`, `LAYER`, `STYLE`, `LTYPE`, `DIMSTYLE`, `VX` | yes, both ends |

VIEW, UCS and VPORT are the three empty tables, and the header gives all three
the **same** address, `0x8518`. The only sentinel written for the group is
`VPORT_END` — which then occupies the 16 bytes where `APPID_BEGIN` would go.
DIMSTYLE and VX are empty as well and *do* carry both sentinels, so this is the
writer being irregular, not a rule of the format. @leshasoft and
@michal-josef-spacek both said as much in the thread; ODA File Converter reads
it without complaint.

## Why reading on is safe here

@rurban, in that thread:

> Maybe check against the natural address for the sentinel, when the
> table.address fails.

This takes the other half of that: the sentinel is a **delimiter**, not the
locator. Records are read from `tbl->address`, which the header states
independently of the sentinel, and every pre-R13 table record carries its own
CRC — which this code already verifies:

```
crc: B405 [RSx]
 check_CRC 32146-32335 = 189: B405 == B405
```

So a wrong address is caught on its own merits instead of being inferred from a
missing delimiter. Warn, read the table from its header address, carry on.

`DWG_ERR_INVALIDDWG` stays fatal: that one means the 16 bytes could not be read
at all, so the position itself is nonsense — a different condition from "the
sentinel is not there".

The `not found` message in `decode_preR13_sentinel` becomes a warning for the
same reason: fatality is the caller's decision, and a caller that *does* give up
still reports it through `Failed to decode file`. Without that change a file
which now converts perfectly still logged six `ERROR` lines, which any CI or
bench that greps for `ERROR` reads as a failure. Say the word if you would
rather keep it an error and I will drop that hunk.

## Result

| | entities |
|---|---|
| stock | **no output at all** |
| with this patch | **553** |
| ODA File Converter 25.6 | 553 |

All 553 are `LINE`. Rendering both DXFs through ezdxf's SVG backend gives
**byte-identical** output, 29433 bytes each — so it is not only the count that
matches.

The two other files in the thread (@michal-josef-spacek's regenerated `F.DWG`
and @leshasoft's repaired `qq.zip`) already converted before this patch and are
unchanged by it, as expected: their sentinels are all present.

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged.
- All **148** DWGs in `test/test-data` and `programs/` converted before and
  after: **148 byte-identical, 0 worse**. None of them is missing a sentinel, so
  none takes the new path.
- All **18 pre-R13 drawings** in a 1657-file corpus (4× AC1003, AC1004,
  3× AC1006, 8× AC1009, 2× AC1012): **4115 entities before and after, 0
  changed, 0 regressions**.

Built on Ubuntu 26.04, gcc 15.2.0, on a **clean** `e405fcff` (= tag `0.14.8556`)
with this patch alone, so it does not lean on my other open PRs. It composes
with #1362 without overlapping: that one widens the search for a sentinel that
*is* present but displaced; this one survives a sentinel that is genuinely
absent.
