### PR TITLE
dwg_read_dxf: a DXF without a trailing newline lost its last group pair

### DIFF
--- a/src/dwg.c
+++ b/src/dwg.c
@@ -421,10 +421,15 @@ ENDSEC
       dat.size = 0;
       return DWG_ERR_IOERROR;
     }
-  // properly end the buffer for strtol()/... readers
+  /* properly end the buffer for strtol()/... readers. The NUL has to go after
+     the newline we just appended, not on top of it: the chain is calloc'd with
+     two spare bytes for exactly this. Overwriting it left the buffer ending in
+     "...\n0\0" for a DXF without a trailing newline, and dxf_read_string
+     bails out when it finds no '\n' in what is left -- so the file's last
+     group pair was lost and the whole import failed. */
   if (dat.chain[size - 1] != '\n')
     {
-      dat.chain[size] = '\n';
+      dat.chain[size++] = '\n';
       dat.size++;
     }
   dat.chain[size] = '\0';


### PR DESCRIPTION
Found while looking at #474, but it is not specific to that file.

```c
  // properly end the buffer for strtol()/... readers
  if (dat.chain[size - 1] != '\n')
    {
      dat.chain[size] = '\n';
      dat.size++;
    }
  dat.chain[size] = '\0';
```

The newline is appended at `chain[size]` and then **overwritten by the NUL at
the same index**. `dat.size` was already incremented, so the buffer ends
`...\n0\0` with `size` pointing past a NUL that stands exactly where the newline
should be.

`dxf_read_string` then refuses to read the value:

```c
      if (dat->byte >= dat->size
          || !memchr (&dat->chain[dat->byte], '\n', dat->size - dat->byte))
        return;
```

It leaves `*string` NULL, and the caller reports that as:

```
ERROR: Out of memory
ERROR: Failed to decode DXF file: my-drawing.dxf
READ ERROR 0x1000
```

— on an 18 KB file. The chain is `calloc`'d with two spare bytes for exactly
this case, so the NUL simply has to go after the newline.

## The class of files affected

Any DXF whose last byte is not a newline, whatever it contains: the loss always
falls on the final `0`/`EOF` pair, so the file is rejected outright.

Same DXF, differing only in that one byte:

| | `dxf2dwg` result |
|---|---|
| ends with a newline | 5139-byte DWG |
| ends without one | **fails, no output** |

With this patch both produce the same 5139 bytes, byte for byte. The
`my-drawing.dxf` attached to #474 (from Maker.js, ending `0\nEOF`) now converts
to a 12696-byte AC1015 DWG instead of failing.

## This does not close #474

The DWG it now produces is still rejected by ODA File Converter 25.6:

```
OdError thrown during readFile: Null object Id: <object> (0)
```

which is exactly what @rurban diagnosed in that thread in 2022:

> The problem is that such a minimal DXF contains no handles, and we use the
> handles internally to find table entries. Thus we need to assign handles
> ourselves, at least on table controls and its entries.

Still true, and a separate fix. This one only stops the import from failing
outright — and fixes every other DXF that happens to end without a newline,
which was the part that looked like a memory error.

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged.
- Eight real DXFs (26 KB to 47 MB) through `dxf2dwg` before and after: every DWG
  **byte-identical**. Two of them produce no output on either side, unrelated to
  this; the other six match exactly.
- Built and tested on a **clean** `e405fcff` (= tag `0.14.8556`) with this patch
  alone, so it does not lean on my other open PRs. Ubuntu 26.04, gcc 15.2.0.
