### PR TITLE
bits: never encode a UTF-16 surrogate into the UTF-8 output

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -2925,6 +2925,28 @@ bit_read_T (Bit_Chain *restrict dat)
     return (BITCODE_T)bit_read_TV (dat);
 }
 
+/* U+D800..U+DFFF are UTF-16 surrogate halves. They stand for a code point only
+   in pairs, and RFC 3629 forbids encoding them in UTF-8 at all -- which is why
+   bit_utf8_to_TU above already refuses them on the way in ("reject overlong
+   encodings and UTF-16 surrogates"). Writing them out regardless, as the
+   "windows ucs-2 has no D800-DC00 surrogate pairs, go straight up" comments
+   below assumed was safe, produces a DXF that no UTF-8 decoder accepts: iconv
+   and Python reject the file, and AutoCAD refuses the whole drawing over a
+   single such name (GH #1021, an APPID whose name in the DWG is damaged). One
+   surrogate makes 106000 good lines unreadable.
+
+   U+FFFD is the standard substitute and takes the same three bytes, so nothing
+   else about these loops changes. Combining a genuine pair into the
+   supplementary code point it denotes would recover more, and is the natural
+   next step; this only guarantees the output is well-formed. */
+#define NO_LONE_SURROGATE(c)                                                  \
+  do                                                                          \
+    {                                                                         \
+      if ((c) >= 0xD800 && (c) <= 0xDFFF)                                     \
+        (c) = 0xFFFD;                                                         \
+    }                                                                         \
+  while (0)
+
 /* converts UCS-2LE to UTF-8.
    first pass to get the dest len. single malloc.
  */
@@ -3001,6 +3023,7 @@ bit_convert_TU (const BITCODE_TU restrict wstr)
             }
           else /* if (c < 0x10000) */
             {
+              NO_LONE_SURROGATE (c);
               str[i++] = (c >> 12) | 0xE0;
               str[i++] = ((c >> 6) & 0x3F) | 0x80;
               str[i++] = (c & 0x3F) | 0x80;
@@ -3030,6 +3053,7 @@ bit_convert_TU (const BITCODE_TU restrict wstr)
               str = realloc(str, i+3);
               len = i+2;
             }*/
+            NO_LONE_SURROGATE (c);
             str[i++] = (c >> 12) | 0xE0;
             str[i++] = ((c >> 6) & 0x3F) | 0x80;
             str[i++] = (c & 0x3F) | 0x80;
@@ -3123,6 +3147,7 @@ bit_convert_TU_len (const BITCODE_TU restrict wstr, const size_t max_wchars)
             }
           else
             {
+              NO_LONE_SURROGATE (c);
               str[i++] = (c >> 12) | 0xE0;
               str[i++] = ((c >> 6) & 0x3F) | 0x80;
               str[i++] = (c & 0x3F) | 0x80;
@@ -3144,6 +3169,7 @@ bit_convert_TU_len (const BITCODE_TU restrict wstr, const size_t max_wchars)
           }
         else
           {
+            NO_LONE_SURROGATE (c);
             str[i++] = (c >> 12) | 0xE0;
             str[i++] = ((c >> 6) & 0x3F) | 0x80;
             str[i++] = (c & 0x3F) | 0x80;
@@ -3211,6 +3237,7 @@ bit_TU_to_utf8_len (const BITCODE_TU restrict wstr, const int len)
           else /* if (c < 0x10000) */
             {
               EXTEND_SIZE (str, i + 2, len);
+              NO_LONE_SURROGATE (c);
               str[i++] = (c >> 12) | 0xE0;
               str[i++] = ((c >> 6) & 0x3F) | 0x80;
               str[i++] = (c & 0x3F) | 0x80;
@@ -3242,6 +3269,7 @@ bit_TU_to_utf8_len (const BITCODE_TU restrict wstr, const int len)
               len = i+2;
             }*/
             EXTEND_SIZE (str, i + 2, len);
+            NO_LONE_SURROGATE (c);
             str[i++] = (c >> 12) | 0xE0;
             str[i++] = ((c >> 6) & 0x3F) | 0x80;
             str[i++] = (c & 0x3F) | 0x80;


### PR DESCRIPTION
Addresses #1021. Reproducer: `Stahl.dwg` from the `dev2.zip` @Mannshoch attached
to that thread — four of its five drawings show it.

The UTF-16 → UTF-8 loops encode any code unit `>= 0x800` as a three-byte
sequence, on the strength of this comment:

```c
        else /* if (c < 0x10000) */
          {  /* windows ucs-2 has no D800-DC00 surrogate pairs. go straight up
              */
            str[i++] = (c >> 12) | 0xE0;
```

`U+D800..U+DFFF` are surrogate halves. They stand for a code point only in
pairs, and RFC 3629 forbids encoding them in UTF-8 at all. **The decoder in the
same file already knows this:**

```c
                      // reject overlong encodings and UTF-16 surrogates
                      if (cp >= 0x800 && (cp < 0xD800 || cp > 0xDFFF))
```

So a string that does contain one goes out as bytes no UTF-8 decoder will
accept — and a DXF for R2007 or later is UTF-8.

## What it costs in #1021

One APPID whose name in the DWG is damaged:

```
AT_JNT_\xed\xb4\xb8\xe0\xae\xb5\xed\xb4\xb8\xe0\xae\xb5\xe9\xbd\x8f...
```

`\xed\xb4\xb8` is U+DD38, a lone low surrogate. `iconv -f UTF-8` and Python both
reject the file, and @Mannshoch's AutoCAD refuses the drawing:

```
Error in in APPID Table
DXF-ReadError auf Line 106298.
Invalid or incomplete DXF input -- drawing canceled.
```

106000 sound lines lost over one name. For comparison, ODA File Converter reads
the same DWG and writes that record as `$TD_AUDIT_GENERATED_(10E7)` — so it
agrees the name is unusable; it just does not emit anything invalid over it.

| drawing | before | after |
|---|---|---|
| `Platte.dwg` | invalid UTF-8 | **valid** |
| `Stahl.dwg` | invalid UTF-8 | **valid** |
| `Teile.dwg` | invalid UTF-8 | **valid** |
| `xx17.dwg` | invalid UTF-8 | **valid** |
| `test-trichter.dwg` | valid | valid, byte-identical |

The four DXFs differ by **exactly six bytes each** — the two surrogates. U+FFFD
is the standard substitute and takes the same three bytes, so none of these
loops changes shape and no buffer arithmetic moves.

## What I deliberately left out

Combining a genuine surrogate **pair** into the supplementary code point it
denotes would recover more than U+FFFD does, and it would write four bytes where
six are already reserved, so it needs no allocation change either. I kept this
patch to one uniform guard applied at all six UTF-16 sites so it is easy to
verify; happy to follow up with the pair handling if you want it.

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged. `bit_convert_TU` has
  a unit test in `bits_test.c`; its data is BMP-only, so it is unaffected.
- All **146** DWGs in `test/test-data` and `programs/` converted before and
  after: **146 byte-identical**. None of them carries a surrogate.
- Three of those 146 *do* emit invalid UTF-8, and this patch leaves them alone on
  purpose: `example_2000`, `example_r13` and `2000/TS1` write the degree sign as
  the single byte `0xB0`. They are `$ACADVER AC1015` with `$DWGCODEPAGE
  ANSI_1252`, and a pre-R2007 DXF is in the drawing's code page rather than
  UTF-8, so `0xB0` is right there. The rule this patch enforces is only about the
  UTF-16 conversions — the codepage path at the end of `bit_TV_to_utf8` is
  untouched.
- Built and tested on a **clean** `e405fcff` (= tag `0.14.8556`) with this patch
  alone, so it does not lean on my other open PRs. Ubuntu 26.04, gcc 15.2.0.

This does not close #1021 by itself — @Mannshoch's own file is not shareable and
the thread lists several other problems in those drawings (BLOCKSTRETCHACTION,
ASSOCPERSSUBENTMANAGER, the section-reading issue of #948). But the APPID table
error he quoted, which is what cancels the import, is this.
