### PR TITLE
r11: give pre-R13 drawings their paper space BLOCK_HEADER (fixes #1337)

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -6952,12 +6952,14 @@ decode_preR13_entities (BITCODE_RL start, BITCODE_RL end,
   BITCODE_BL num = dwg->num_objects;
   BITCODE_RL real_start = start;
   size_t oldpos;
-  BITCODE_RLL hdr_handle = 0;
+  BITCODE_RLL hdr_handle = 0, phdr_handle = 0;
+  Dwg_Object *phdr = NULL;
+  Dwg_Object_BLOCK_HEADER *_phdr = NULL;
   const char *entities_section[]
       = { "entities", "blocks entities", "extras entities" };
   Dwg_Object *hdr = NULL;
   Dwg_Object_BLOCK_HEADER *_hdr = NULL;
-  BITCODE_BL block_idx = 0, hdr_index = 0;
+  BITCODE_BL block_idx = 0, hdr_index = 0, phdr_index = 0;
 
   LOG_TRACE ("\n%s: (" FORMAT_RLx "-" FORMAT_RLx " (%u), size " FORMAT_RL
              ")\n",
@@ -6994,6 +6996,22 @@ decode_preR13_entities (BITCODE_RL start, BITCODE_RL end,
           hdr_handle = hdr->handle.value;
           LOG_TRACE ("owned by BLOCK %s (" FORMAT_HV ")\n", _hdr->name,
                      hdr_handle);
+        }
+      /* The r11 entities section holds both spaces, told apart by the
+         FLAG_R11_HAS_PSPACE flag which the decoder turns into entmode 1. Each
+         has to land in its own BLOCK_HEADER, or a reader walking the layouts
+         finds an empty paper space and a model space holding both (GH #1337). */
+      phdr = dwg_paper_space_object (dwg);
+      if (phdr && phdr->fixedtype == DWG_TYPE_BLOCK_HEADER)
+        {
+          phdr_index = phdr->index;
+          _phdr = phdr->tio.object->tio.BLOCK_HEADER;
+          _phdr->block_offset_r11 = (BITCODE_RL)-1;
+          if (!phdr->handle.value)
+            phdr->handle.value = dwg_next_handle (dwg);
+          phdr_handle = phdr->handle.value;
+          LOG_TRACE ("paper space is BLOCK %s (" FORMAT_HV ")\n", _phdr->name,
+                     phdr_handle);
         }
     }
   // TODO search current offset in block_offset_r11 in BLOCK_HEADER's
@@ -7535,17 +7553,21 @@ decode_preR13_entities (BITCODE_RL start, BITCODE_RL end,
               && obj->fixedtype != DWG_TYPE_SEQEND)
             {
               BITCODE_H ref;
+              /* paper space, if this drawing has one and the entity says so */
+              const bool to_pspace = _phdr && phdr_handle
+                                     && obj->tio.entity->entmode == 1;
+              Dwg_Object_BLOCK_HEADER *_owner = to_pspace ? _phdr : _hdr;
               if (!obj->handle.value)
                 obj->handle.value = dwg_next_handle (dwg);
-              hdr = &dwg->object[hdr_index];
+              hdr = &dwg->object[to_pspace ? phdr_index : hdr_index];
               ref = dwg_add_handleref (dwg, 3, obj->handle.value, hdr);
               // if (dwg->dirty_refs)
               // find _hdr again from hdr_handle
-              LOG_TRACE ("BLOCK_HEADER \"%s\".", _hdr->name);
+              LOG_TRACE ("BLOCK_HEADER \"%s\".", _owner->name);
               if (obj->fixedtype != DWG_TYPE_BLOCK)
-                PUSH_HV (_hdr, num_owned, entities, ref);
-              obj->tio.entity->ownerhandle
-                  = dwg_add_handleref (dwg, 4, hdr_handle, obj);
+                PUSH_HV (_owner, num_owned, entities, ref);
+              obj->tio.entity->ownerhandle = dwg_add_handleref (
+                  dwg, 4, to_pspace ? phdr_handle : hdr_handle, obj);
               obj->tio.entity->ownerhandle->r11_idx = block_idx;
               LOG_TRACE ("ownerhandle: " FORMAT_HREF11 "\n",
                          ARGS_HREF11 (obj->tio.entity->ownerhandle));

--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -25324,7 +25324,12 @@ dwg_add_Document (Dwg_Data *restrict dwg, const int imperial)
   dwg->header_vars.BLOCK_RECORD_MSPACE->obj = mspaceobj;
   block_control->model_space
       = dwg_add_handleref (dwg, 3, mspaceobj->handle.value, NULL);
-  if (version >= R_13b1)
+  /* r11 and r12 have a paper space too -- that is what the entity flag
+     FLAG_R11_HAS_PSPACE marks, and AutoCAD writes a $PAPER_SPACE block for it.
+     Without the BLOCK_HEADER, dwg_paper_space_object() finds nothing, the
+     paper-space entities end up owned by model space, and the DXF loses the
+     block record entirely (GH #1337). */
+  if (version >= R_11)
     {
       // BLOCK_RECORD_PSPACE: (5.1.20)
       dwg_set_next_hdl (dwg, UINT64_C (0x20));
@@ -25344,10 +25349,26 @@ dwg_add_Document (Dwg_Data *restrict dwg, const int imperial)
       dwg->block_control = *block_control;
       // BLOCK: (5.1.21)
       dwg_set_next_hdl (dwg, UINT64_C (0x21));
-      dwg_add_BLOCK (pspace, "*PAPER_SPACE");
+      {
+        Dwg_Entity_BLOCK *pblock = dwg_add_BLOCK (pspace, "*PAPER_SPACE");
+        if (dwg->header.version <= R_12) // fixup the type, as for mspace below
+          {
+            obj = dwg_obj_generic_to_object (pblock, &error);
+            if (obj)
+              obj->type = DWG_TYPE_UNUSED_r11; // don't encode it
+          }
+      }
       // ENDBLK: (5.1.22)
       dwg_set_next_hdl (dwg, UINT64_C (0x22));
-      dwg_add_ENDBLK (pspace);
+      {
+        Dwg_Entity_ENDBLK *pendblk = dwg_add_ENDBLK (pspace);
+        if (dwg->header.version <= R_12) // fixup the type
+          {
+            obj = dwg_obj_generic_to_object (pendblk, &error);
+            if (obj)
+              obj->type = DWG_TYPE_UNUSED_r11; // don't encode it
+          }
+      }
     }
   // LAYOUT (0.1.23)
   // dwg_set_next_hdl (dwg, UINT64_C (0x23));

--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -1874,19 +1874,24 @@ dxf_cvt_blockname (Bit_Chain *restrict dat, char *restrict name, const int dxf)
         free (name);
       return;
     }
-  if (dat->version == dat->from_version) // no conversion
+  /* The name depends on the DXF being written, not on where the drawing came
+     from: a pre-R13 DXF spells the two spaces $MODEL_SPACE and $PAPER_SPACE,
+     whatever they are called internally. Keying this off
+     "version != from_version" left an r11 -> r11 conversion writing
+     *MODEL_SPACE, which is not what AutoCAD writes (GH #1337). */
+  if (dat->version == dat->from_version && dat->version >= R_13b1)
     {
       fprintf (dat->fh, "%3i\r\n%s\r\n", dxf, name);
     }
-  else if (dat->version < R_13b1 && dat->from_version >= R_13b1) // to older
+  else if (dat->version < R_13b1) // to pre-R13
     {
-      if (strlen (name) < 10)
-        fprintf (dat->fh, "%3i\r\n%s\r\n", dxf, name);
-      else if (strEQc (name, "*Model_Space"))
+      if (strEQc (name, "*Model_Space") || strEQc (name, "*MODEL_SPACE"))
         fprintf (dat->fh, "%3i\r\n$MODEL_SPACE\r\n", dxf);
-      else if (strEQc (name, "*Paper_Space"))
+      else if (strEQc (name, "*Paper_Space") || strEQc (name, "*PAPER_SPACE"))
         fprintf (dat->fh, "%3i\r\n$PAPER_SPACE\r\n", dxf);
       else if (strlen (name) >= 12 && !memcmp (name, "*Paper_Space", 12))
+        fprintf (dat->fh, "%3i\r\n$PAPER_SPACE%s\r\n", dxf, &name[12]);
+      else if (strlen (name) >= 12 && !memcmp (name, "*PAPER_SPACE", 12))
         fprintf (dat->fh, "%3i\r\n$PAPER_SPACE%s\r\n", dxf, &name[12]);
       else
         fprintf (dat->fh, "%3i\r\n%s\r\n", dxf, name);


### PR DESCRIPTION
Fixes #1337, doing what was agreed there:

> **@michal-josef-spacek:** I think we need to create pspace object and assign
> entities with HAS_PSPACE to it.
>
> **@rurban:** Of course

Half of it is already done, which is worth knowing before reading the diff. The
**entity side is correct**: `common_entity_data.spec` sets `entmode = 1` for
`FLAG_R11_HAS_PSPACE`, and the DXF writer emits group 67 from it —

```c
      if (R11FLAG (FLAG_R11_HAS_PSPACE)) { // 16
#ifdef IS_DECODER
        _ent->entmode = 1;
#endif
        DXF { VALUE_RC (1, 67); }
```

— so on the `AC1009.dwg` from this issue all eight entities already come out with
the same group 67 AutoCAD writes: three without it, five with `67 1`. **What is
missing is the container.**

`dwg_add_Document` gates the paper space `BLOCK_HEADER` behind
`version >= R_13b1`:

```c
  if (version >= R_13b1)
    {
      // BLOCK_RECORD_PSPACE: (5.1.20)
      dwg_set_next_hdl (dwg, UINT64_C (0x20));
      pspace = dwg_add_BLOCK_HEADER (dwg, "*PAPER_SPACE");
```

So a pre-R13 drawing never gets one — `dwg_paper_space_object()` returns nothing,
every entity is pushed into the model space header, and the DXF has no
`$PAPER_SPACE` block record at all.

## The three changes

- **`dwg_api.c`** — create the `*PAPER_SPACE` BLOCK_HEADER from `R_11` on, with
  the same *"fixup the type to `DWG_TYPE_UNUSED_r11` so it is not encoded"*
  treatment its BLOCK and ENDBLK already get for model space a few lines below.
- **`decode.c`** — `decode_preR13_entities` routes an entity with
  `entmode == 1` to that header, model space otherwise. The old code took
  `hdr_index` unconditionally.
- **`out_dxf.c`** — `dxf_cvt_blockname` keyed the `$MODEL_SPACE`/`$PAPER_SPACE`
  spelling off `version != from_version`, so an **r11 → r11** conversion wrote
  `*MODEL_SPACE`. The name depends on the DXF being written, not on where the
  drawing came from. It also now accepts the upper-case `*MODEL_SPACE` /
  `*PAPER_SPACE` forms the pre-R13 path itself produces.

## Result on the `AC1009.dwg` from this issue

Against the `AC1009.dxf` AutoCAD wrote from the same drawing:

| | BLOCKS |
|---|---|
| before | `[*MODEL_SPACE]` |
| **after** | **`[$MODEL_SPACE, $PAPER_SPACE]`** |
| AutoCAD | `[$MODEL_SPACE, $PAPER_SPACE]` |

| owned entities | `*MODEL_SPACE` | `*PAPER_SPACE` |
|---|---:|---:|
| before | 8 | — (no header) |
| **after** | **3** | **5** |

Which is the split AutoCAD's DXF shows: three entities without group 67, and
`VIEWPORT` plus four `LINE` with `67 1`.

## One difference from AutoCAD I left alone

AutoCAD marks the `$PAPER_SPACE` **block record itself** with group 67; this does
not. The block is identified by its name, and both ezdxf and the AutoCAD DXF
reader reconstruct the layout from the entities' 67 — I checked, ezdxf reports
`Model: 3, Layout1: 5` from either DXF. Setting it would mean reaching into the
synthesized BLOCK entity's r11 flags, so I stopped short. Happy to add it if you
want the record to match byte for byte.

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged.
- All **156** DWGs in `test/test-data` and `programs/` converted before and
  after: **152 byte-identical, 4 changed, 0 that stopped producing output**. The
  four are exactly the AC1009 ones — `programs/ACEB10_r11.dwg`,
  `r11/ACEB10.dwg`, `r11/entities-2d.dwg`, `r11/entities-3d.dwg` — each 60 to 78
  bytes larger, which is the added block record. **Entity counts unchanged on all
  four** (873/2163, 120/654, 13/36, 14/38 before and after).
- **18 pre-R13 drawings** from a 1657-file corpus (4× AC1003, AC1004, 3× AC1006,
  8× AC1009, 2× AC1012): **4115 entities before and after, nothing changed**.
- Built and tested on a **clean** `e405fcff` (= tag `0.14.8556`) with this patch
  alone, so it does not lean on my other open PRs. Ubuntu 26.04, gcc 15.2.0.
