### PR TITLE
TIMEBLL: one julian-day fraction, three wrong conventions for it (fixes #1309)

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -3937,7 +3937,7 @@ bit_read_TIMEBLL (Bit_Chain *dat)
       date.days = bit_read_BL (dat);
       date.ms = bit_read_BL (dat);
     }
-  date.value = date.days + (date.ms * 1e-8);
+  date.value = date.days + (date.ms / TIMEBLL_MS_PER_DAY);
   return date;
 }
 
@@ -3966,7 +3966,7 @@ bit_read_TIMERLL (Bit_Chain *dat)
   date.days = bit_read_RL (dat);
   date.ms = bit_read_RL (dat);
   // just for display, not calculations
-  date.value = date.days + (date.ms * 1e-8);
+  date.value = date.days + (date.ms / TIMEBLL_MS_PER_DAY);
   return date;
 }
 

--- a/src/common.c
+++ b/src/common.c
@@ -539,7 +539,7 @@ cvt_TIMEBLL (struct tm *tm, BITCODE_TIMEBLL date)
 
 #define TRUNC(n) (long)floor (n)
 
-  t = 0.864 * date.ms / 1000.0; /*t=1000000 = 1 day, means 86400 in seconds */
+  t = date.ms / 1000.0; /* ms elapsed in the day -> seconds */
   if (date.days > 2299161)
     {
       jalpha = TRUNC (((date.days - 1867216) - 0.25) / 36524.25);

--- a/src/common.h
+++ b/src/common.h
@@ -33,6 +33,16 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <math.h>
+
+/* A TIMEBLL/TIMERLL is a julian day number plus the milliseconds elapsed in
+   that day, so the fraction of a day it stands for is ms/86400000. The code
+   used to spell that as "ms * 1e-8" in seven places, "0.864 * ms / 1000" in
+   cvt_TIMEBLL and "86400.0 * ms" in json_TIMEBLL -- three mutually
+   incompatible conventions for one field, all of them wrong by 0.864 or worse.
+   dwg_add_Document fills the field itself with 1000 * (now % 86400), i.e.
+   milliseconds, three lines above computing the value as ms * 1e-8. GH #1309. */
+#define TIMEBLL_MS_PER_DAY 86400000.0
+
 #include <time.h>
 #include "dwg.h"
 

--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -25015,7 +25015,7 @@ dwg_add_Document (Dwg_Data *restrict dwg, const int imperial)
     days += 2440588L;
     dwg->header_vars.TDUCREATE
         = (BITCODE_TIMEBLL){ (BITCODE_BL)days, (BITCODE_BL)ms,
-                             days + (ms * 1e-8) };
+                             days + (ms / TIMEBLL_MS_PER_DAY) };
   }
   dwg->header_vars.TDUUPDATE = dwg->header_vars.TDUCREATE;
   // CECOLOR.index: 256 [CMC.BS 62]

--- a/src/header_variables.spec
+++ b/src/header_variables.spec
@@ -276,13 +276,13 @@
       _obj->TDCREATE.days  = _obj->TDUCREATE.days;
       // adjust for timezone offset
       _obj->TDCREATE.ms    = _obj->TDUCREATE.ms + off;
-      _obj->TDCREATE.value = _obj->TDCREATE.days + (_obj->TDCREATE.ms * 1e-8);
+      _obj->TDCREATE.value = _obj->TDCREATE.days + (_obj->TDCREATE.ms / TIMEBLL_MS_PER_DAY);
       strftime (_buf, 60, STRFTIME_DATE, cvt_TIMEBLL (&tm, _obj->TDCREATE));
       LOG_TRACE ("=> TDCREATE: [" FORMAT_BL ", " FORMAT_BL "] %s [TIMEBLL 40]\n",
                    _obj->TDCREATE.days, _obj->TDCREATE.ms, _buf);
       _obj->TDUPDATE.days  = _obj->TDUUPDATE.days;
       _obj->TDUPDATE.ms    = _obj->TDUUPDATE.ms + off;
-      _obj->TDUPDATE.value = _obj->TDUPDATE.days + (_obj->TDUPDATE.ms * 1e-8);
+      _obj->TDUPDATE.value = _obj->TDUPDATE.days + (_obj->TDUPDATE.ms / TIMEBLL_MS_PER_DAY);
       strftime (_buf, 60, STRFTIME_DATE, cvt_TIMEBLL (&tm, _obj->TDUPDATE));
       LOG_TRACE ("=> TDUPDATE: [" FORMAT_BL ", " FORMAT_BL "] %s [TIMEBLL 40]\n",
                    _obj->TDUPDATE.days, _obj->TDUPDATE.ms, _buf);

--- a/src/header_variables_r11.spec
+++ b/src/header_variables_r11.spec
@@ -202,12 +202,15 @@
       _obj->TDUCREATE.days  = _obj->TDCREATE.days;
       // adjust for timezone offset
       _obj->TDUCREATE.ms    = _obj->TDUCREATE.ms - off;
-      _obj->TDUCREATE.value = _obj->TDUCREATE.days + (_obj->TDUCREATE.ms * 1e-8);
+      _obj->TDUCREATE.value = _obj->TDUCREATE.days + (_obj->TDUCREATE.ms / TIMEBLL_MS_PER_DAY);
       LOG_TRACE ("=> TDUCREATE: [" FORMAT_BL ", " FORMAT_BL "] %f [TIMEBLL 40]\n",
                    _obj->TDUCREATE.days, _obj->TDUCREATE.ms, _obj->TDUCREATE.value);
       _obj->TDUUPDATE.days  = _obj->TDUPDATE.days;
       _obj->TDUUPDATE.ms    = _obj->TDUPDATE.ms - off;
-      _obj->TDUUPDATE.value = _obj->TDUPDATE.days + (_obj->TDUPDATE.ms * 1e-8);
+      /* from TDUUPDATE, which is what the two lines above just set: the
+         value has to agree with the days/ms it belongs to, timezone
+         adjustment included. */
+      _obj->TDUUPDATE.value = _obj->TDUUPDATE.days + (_obj->TDUUPDATE.ms / TIMEBLL_MS_PER_DAY);
       LOG_TRACE ("=> TDUUPDATE: [" FORMAT_BL ", " FORMAT_BL "] %f [TIMEBLL 40]\n",
                    _obj->TDUUPDATE.days, _obj->TDUUPDATE.ms, _obj->TDUUPDATE.value);
     }

--- a/src/in_json.c
+++ b/src/in_json.c
@@ -909,9 +909,7 @@ json_TIMEBLL (Bit_Chain *restrict dat, jsmntokens_t *restrict tokens,
       JSON_TOKENS_CHECK_OVERFLOW_VOID
       date->ms = json_long (dat, tokens);
       JSON_TOKENS_CHECK_OVERFLOW_VOID
-      date->value
-          = date->days
-            + (86400.0 * date->ms); // just for display, not calculations
+      date->value = date->days + (date->ms / TIMEBLL_MS_PER_DAY);
     }
   else
     {
@@ -920,7 +918,7 @@ json_TIMEBLL (Bit_Chain *restrict dat, jsmntokens_t *restrict tokens,
       JSON_TOKENS_CHECK_OVERFLOW_VOID
       date->value = num;
       date->days = (BITCODE_BL)trunc (num);
-      date->ms = (BITCODE_BL)(86400.0 * (date->value - date->days));
+      date->ms = (BITCODE_BL)((date->value - date->days) * TIMEBLL_MS_PER_DAY);
     }
   LOG_TRACE ("%s: %.08f (%u, %u) [TIMEBLL]\n", name, date->value, date->days,
              date->ms);


### PR DESCRIPTION
Fixes #1309. @michal-josef-spacek is right, and the same mistake is in seven
other places.

A `TIMEBLL`/`TIMERLL` is a julian day number plus the **milliseconds elapsed in
that day**, so the fraction of a day it stands for is `ms / 86400000`. The tree
spells that three mutually incompatible ways:

| where | what it computes |
|---|---|
| `bits.c` ×2, `header_variables.spec` ×2, `header_variables_r11.spec` ×2, `dwg_api.c` | `value = days + ms * 1e-8` |
| `common.c`, `cvt_TIMEBLL` | `t = 0.864 * ms / 1000` |
| `in_json.c`, `json_TIMEBLL` | `value = days + 86400.0 * ms` |

`1e-8` is **0.864** of `1/86400000`, so the first two are off by exactly that
factor — up to 3.3 hours of a day. The json one is off by twelve orders of
magnitude one way and 1000× the other.

## Two things in the tree settle which reading is right

No spec needed:

- `dwg_add_Document` fills the field itself with
  `BITCODE_RLL ms = 1000 * (now % 86400L)` — **milliseconds** — and three lines
  later computes `days + (ms * 1e-8)`.
- On a drawing here `TIMEBLL` is `[2454831, 77383890]`. As milliseconds that is
  **21:29:43** of the day, which fits. As 1e-6 of a day it would be **77 days**,
  which cannot.

## ODA agrees to every digit it prints

Same DWG through both:

| | before | **after** | ODA 25.6 |
|---|---|---|---|
| `$TDCREATE` | 2454831.593838900 | **2454831.687313542** | 2454831.687313542 |
| `$TDUCREATE` | 2454831.773838900 | **2454831.895646875** | 2454831.895646875 |
| `$TDINDWG` | 1.367709720 | **1.425589954** | 1.4255899537 |

The human-readable form follows: `TDUCREATE` was logged as `2008-12-30 18:34:19`
and is `21:29:43`, with `TDCREATE` five hours earlier — the timezone that drawing
was made in.

`$TDUPDATE` and `$TDUUPDATE` still differ from ODA, and not because of this: ODA
stamps the *conversion* time into them (its value is today's julian day), while
LibreDWG reports what the DWG holds. I would call that LibreDWG being the more
faithful of the two.

## One copy-paste slip fixed in passing

`header_variables_r11.spec` computed `TDUUPDATE.value` from `TDUPDATE.days/ms`,
so the value disagreed with the days/ms it had just set two lines above — missing
the timezone adjustment. The `TDUCREATE` block immediately above it does use its
own fields.

## Why this cannot move a DWG round-trip

`bit_write_TIMEBLL` and `bit_write_TIMERLL` both say *"Ignores the double value"*
and write `days`/`ms`. The `value` field is only ever read for display, DXF group
40 and JSON.

## Verification

- `make check`: **270 PASS / 0 FAIL / 0 SKIP**, unchanged — including the JSON
  round-trip tests, which exercise `json_TIMEBLL`.
- All **156** DWGs in `test/test-data` and `programs/` converted before and
  after: **5 byte-identical** (the ones with no timestamps), **151 differing only
  in numeric lines, 0 with any structural change**. Sampling 25 of them, the most
  any file changes is **12 lines** — the six `$TD` variables, both sides of the
  diff — and every first difference is preceded by a `$TD` name.
- Built and tested on a **clean** `e405fcff` (= tag `0.14.8556`) with this patch
  alone, so it does not lean on my other open PRs. Ubuntu 26.04, gcc 15.2.0.
