### PR TITLE
encode: in_postprocess_SEQEND rewrapped a relative handle value as absolute (AutoCAD rejects the DWG)

### DIFF
--- a/src/encode.c
+++ b/src/encode.c
@@ -7944,7 +7944,7 @@ in_postprocess_SEQEND (Dwg_Object *restrict obj, BITCODE_BL num_owned,
       // need to turn code 3 into absolute 4.
       if (owned[0])
         {
-          hdl = dwg_add_handleref (dwg, 4, owned[0]->handleref.value, NULL);
+          hdl = dwg_add_handleref (dwg, 4, owned[0]->absolute_ref, NULL);
           dwg_dynapi_entity_set_value (ow, owner->name, firstfield, &hdl, 0);
           LOG_TRACE ("%s[0].%s = " FORMAT_REF "[H 0]\n", owner->name,
                      firstfield, ARGS_REF (hdl));
@@ -7952,7 +7952,7 @@ in_postprocess_SEQEND (Dwg_Object *restrict obj, BITCODE_BL num_owned,
       if (owned[num_owned - 1])
         {
           hdl = dwg_add_handleref (
-              dwg, 4, owned[num_owned - 1]->handleref.value, NULL);
+              dwg, 4, owned[num_owned - 1]->absolute_ref, NULL);
           dwg_dynapi_entity_set_value (ow, owner->name, lastfield, &hdl, 0);
           LOG_TRACE ("%s[%u].%s = " FORMAT_REF "[H 0]\n", owner->name,
                      num_owned - 1, lastfield, ARGS_REF (hdl));


### PR DESCRIPTION
### Symptom

Any DWG written by `dxf2dwg` from a DXF containing an INSERT with attributes is **rejected outright by ODA-based readers** (AutoCAD, ODAFileConverter, BricsCAD):

```
OdError thrown during readFile of drawing "attrib.dwg":
  Object improperly read: <AcDbBlockReference> (33)
 Previous error: Object of class AcDbLinetypeTable can't be cast to AcDbEntity.
```

### Reproducer

```python
import ezdxf   # any DXF writer that stores attributes will do
d = ezdxf.new("R2000")
blk = d.blocks.new("B1"); blk.add_circle((0, 0), 2)
ref = d.modelspace().add_blockref("B1", (5, 5))
ref.add_attrib("TAG0", "VALUE0", (5, 4))
d.saveas("attrib.dxf")
```
`dxf2dwg -y --as r2000 attrib.dxf` → open `attrib.dwg` in anything ODA-based.

### Root cause

`dxf_postprocess_SEQEND` collects the owned ATTRIBs as handlerefs **created with an owner**, so `dwg_add_handle` may store `handleref.value` as a *relative offset*. `in_postprocess_SEQEND` then rewraps that value as if it were absolute:

```c
hdl = dwg_add_handleref (dwg, 4, owned[0]->handleref.value, NULL);
```

For an INSERT 0x51 with one ATTRIB 0x53 the stored value is the offset **+2**, so `first_attrib`/`last_attrib` end up as absolute handle **2** — the LTYPE control object. Hence ODA's "LinetypeTable can't be cast to Entity".

### Fix

Use `absolute_ref`, exactly as `dwg_dup_handleref` does for the same rewrap. (`first_vertex`/`last_vertex` were unaffected only because POLYLINE children use code 3, which is not relativized.)

With this one-liner the same DWG opens in ODA without error, and `dwg2dxf` round-trips the ATTRIB again. Found by a round-trip fuzzer (ezdxf → dxf2dwg → dwg2dxf → compare); no regression on `make check` (254 tests) nor on a 1657-file real-DWG corpus.
