### PR TITLE
in_dxf: store subentities as AutoCAD does — entmode 0, owned by the parent entity

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -9512,6 +9512,8 @@ dxf_postprocess_SEQEND (Dwg_Object *restrict obj)
       return;
     }
   obj->tio.entity->ownerhandle->obj = NULL;
+  // AutoCAD stores subentities with entmode 0, owned by the parent entity
+  obj->tio.entity->entmode = 0;
   owhdls = memBEGINc (owner->name, "POLYLINE_") ? "vertex" : "attribs";
   ow = owner->tio.entity->tio.POLYLINE_2D;
 
@@ -9525,6 +9527,14 @@ dxf_postprocess_SEQEND (Dwg_Object *restrict obj)
     {
       Dwg_Object *_o = &dwg->object[i];
       num_owned = j + 1;
+      if (_o->supertype == DWG_SUPERTYPE_ENTITY && _o->tio.entity)
+        {
+          // as with the SEQEND: entmode 0, owned by the parent entity,
+          // whatever the 330 in the DXF pointed to
+          _o->tio.entity->entmode = 0;
+          _o->tio.entity->ownerhandle
+              = dwg_add_handleref (dwg, 4, owner->handle.value, _o);
+        }
       if (dwg->header.from_version >= R_13b1)
         {
           // Match the encoder's expected handle relation-code for the owned
@@ -14449,7 +14459,22 @@ dxf_entities_read (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
                   obj = &dwg->object[last_ent];
                   ent = obj->tio.entity;
                 }
-              if (ent->ownerhandle)
+              if (obj->fixedtype == DWG_TYPE_ATTRIB
+                  || obj->fixedtype == DWG_TYPE_SEQEND
+                  || obj->fixedtype == DWG_TYPE_VERTEX_2D
+                  || obj->fixedtype == DWG_TYPE_VERTEX_3D
+                  || obj->fixedtype == DWG_TYPE_VERTEX_MESH
+                  || obj->fixedtype == DWG_TYPE_VERTEX_PFACE
+                  || obj->fixedtype == DWG_TYPE_VERTEX_PFACE_FACE)
+                {
+                  // Subentity: owned by its INSERT/POLYLINE parent, not by
+                  // the block. AutoCAD stores it with entmode 0 and keeps it
+                  // out of the block's entity chain; filing it under the
+                  // block corrupts the chain for conformant readers.
+                  // dxf_postprocess_SEQEND resets its owner to the parent.
+                  ent->entmode = 0;
+                }
+              else if (ent->ownerhandle)
                 {
                   if (ent->ownerhandle->absolute_ref == mspace)
                     ent->entmode = 2;
@@ -14457,7 +14482,6 @@ dxf_entities_read (Bit_Chain *restrict dat, Dwg_Data *restrict dwg)
                     ent->entmode = 1;
                   else if (dwg->header.from_version < R_13b1)
                     {
-                      // SEQEND/VERTEX: owner is INSERT/POLYLINE, not mspace.
                       // Inherit entmode from the parent entity.
                       Dwg_Object *owner_obj = dwg_resolve_handle (
                           dwg, ent->ownerhandle->absolute_ref);


### PR DESCRIPTION
### Symptom

Even with the `first_attrib` fix (#1370), DWGs written by `dxf2dwg` store ATTRIB/VERTEX/SEQEND unlike AutoCAD does, and ODA-based readers silently **drop the ATTRIBs of every INSERT and the last VERTEX of every POLYLINE** (a 3-vertex 3D polyline comes back with 2).

### What AutoCAD does (measured)

Feeding the same DXF to ODAFileConverter and reading the resulting r2000 DWG with `dwgread`:

| | ours (before) | ODA reference |
|---|---|---|
| subentity `entmode` | 2 | **0** |
| subentity `ownerhandle` | block record | **the parent INSERT/POLYLINE** |
| block header chain | contains subentities | **top-level entities only** |
| SEQEND | entmode 0, chained nowhere | entmode 0, owned by parent |

The importer filed ATTRIB/VERTEX under the block header (their DXF 330 points at the block record — that is how ezdxf and AutoCAD write DXF), with entmode 2, while the SEQEND (owner rewritten to the parent entity by `dxf_postprocess_SEQEND`) silently failed `add_to_BLOCK_HEADER` and stayed entmode 0, outside every chain.

### Fix

* never file ATTRIB/VERTEX*/SEQEND under a block header;
* `dxf_postprocess_SEQEND` sets each child's `ownerhandle` to the parent entity and `entmode` 0, whatever their 330 pointed to — same for the SEQEND itself.

After this the emitted structure matches the ODA reference field for field, ODA reads back **all** vertices and attributes, and the LibreDWG round trip is clean. Found by a round-trip fuzzer; `make check` (254 tests) and a 1657-file real-DWG corpus show no regression.
