### PR TITLE
out_dxf: do not write stale subentities a second time

### DIFF
--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -3046,27 +3046,57 @@ decl_dxf_process_INSERT (MINSERT)
 
     case DWG_TYPE_ATTRIB:
       if (dat->version >= R_13b1)
-        LOG_WARN ("stale %s subentity", obj->dxfname);
+        {
+          // already written via its parent entity; writing it again
+          // here would duplicate it after the SEQEND
+          LOG_WARN ("stale %s subentity", obj->dxfname);
+          return 0;
+        }
       return dwg_dxf_ATTRIB (dat, obj);
     case DWG_TYPE_VERTEX_2D:
       if (dat->version >= R_13b1)
-        LOG_WARN ("stale %s subentity", obj->dxfname);
+        {
+          // already written via its parent entity; writing it again
+          // here would duplicate it after the SEQEND
+          LOG_WARN ("stale %s subentity", obj->dxfname);
+          return 0;
+        }
       return dwg_dxf_VERTEX_2D (dat, obj);
     case DWG_TYPE_VERTEX_3D:
       if (dat->version >= R_13b1)
-        LOG_WARN ("stale %s subentity", obj->dxfname);
+        {
+          // already written via its parent entity; writing it again
+          // here would duplicate it after the SEQEND
+          LOG_WARN ("stale %s subentity", obj->dxfname);
+          return 0;
+        }
       return dwg_dxf_VERTEX_3D (dat, obj);
     case DWG_TYPE_VERTEX_MESH:
       if (dat->version >= R_13b1)
-        LOG_WARN ("stale %s subentity", obj->dxfname);
+        {
+          // already written via its parent entity; writing it again
+          // here would duplicate it after the SEQEND
+          LOG_WARN ("stale %s subentity", obj->dxfname);
+          return 0;
+        }
       return dwg_dxf_VERTEX_MESH (dat, obj);
     case DWG_TYPE_VERTEX_PFACE:
       if (dat->version >= R_13b1)
-        LOG_WARN ("stale %s subentity", obj->dxfname);
+        {
+          // already written via its parent entity; writing it again
+          // here would duplicate it after the SEQEND
+          LOG_WARN ("stale %s subentity", obj->dxfname);
+          return 0;
+        }
       return dwg_dxf_VERTEX_PFACE (dat, obj);
     case DWG_TYPE_VERTEX_PFACE_FACE:
       if (dat->version >= R_13b1)
-        LOG_WARN ("stale %s subentity", obj->dxfname);
+        {
+          // already written via its parent entity; writing it again
+          // here would duplicate it after the SEQEND
+          LOG_WARN ("stale %s subentity", obj->dxfname);
+          return 0;
+        }
       return dwg_dxf_VERTEX_PFACE_FACE (dat, obj);
 
     case DWG_TYPE_ARC:


### PR DESCRIPTION
### Symptom

`dwg2dxf` of a DWG whose ATTRIB/VERTEX subentities appear in the block's entity chain (as `dxf2dwg` used to write them — see #1371) emits **every POLYLINE vertex twice**: once through the owner's vertex walk, then again after the SEQEND:

```
POLYLINE(2F) VERTEX(31) VERTEX(32) VERTEX(33) SEQEND(30) VERTEX(31) VERTEX(32) VERTEX(33)
```

Importers then either drop the trailing vertices or keep them as stray entities (ezdxf shows 9 extra loose VERTEX in a drawing with three 3-vertex polylines).

### The internal contradiction

`dwg_dxf_object` already knows these are wrong — it has warned `"stale %s subentity"` since ever — and then **writes them anyway**, while the SEQEND and ENDBLK cases right above return 0:

```c
case DWG_TYPE_SEQEND:
  if (dat->version >= R_13b1)
    { LOG_WARN ("stale %s subentity", obj->dxfname); return 0; }   // skips
...
case DWG_TYPE_VERTEX_3D:
  if (dat->version >= R_13b1)
    LOG_WARN ("stale %s subentity", obj->dxfname);
  return dwg_dxf_VERTEX_3D (dat, obj);                              // writes!
```

### Fix

Make the six ATTRIB/VERTEX cases behave like SEQEND: warn and skip. They are always written through their parent entity's process function; a second copy at the top level is never valid r13+ DXF. This also repairs reading the LibreDWG-written DWGs already out in the wild.

Found by a round-trip fuzzer; `make check` and a 1657-file real-DWG corpus show no regression.
