### PR TITLE
out_dxf: a block header without BLOCK must not abort the whole DXF

### DIFF
--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -3878,16 +3878,20 @@ dxf_block_write (Bit_Chain *restrict dat, const Dwg_Object *restrict hdr,
     {
       SINCE (R_2004a)
       {
-        // first_owned_block
+        // first_owned_block. E.g. an orphaned duplicate *Model_Space from a
+        // DXF import. Skip just this block header: aborting would throw away
+        // every remaining block and the whole ENTITIES section, as r2000
+        // (which falls through here) does not.
         if (IS_FROM_TU (dat))
           {
             char *s = bit_convert_TU ((BITCODE_TU)_hdr->name);
-            LOG_ERROR ("BLOCK_HEADER %s first_owned_entity missing", s);
+            LOG_WARN ("BLOCK_HEADER %s first_owned_entity missing, skipped", s);
             free (s);
           }
         else
-          LOG_ERROR ("BLOCK_HEADER %s first_owned_entity missing", _hdr->name);
-        return DWG_ERR_INVALIDDWG;
+          LOG_WARN ("BLOCK_HEADER %s first_owned_entity missing, skipped",
+                    _hdr->name);
+        return 0;
       }
     }
 

--- a/src/out_dxfb.c
+++ b/src/out_dxfb.c
@@ -2368,15 +2368,20 @@ dxfb_block_write (Bit_Chain *restrict dat, const Dwg_Object *restrict hdr,
     {
       SINCE (R_2004a)
       {
+        // E.g. an orphaned duplicate *Model_Space from a DXF import. Skip
+        // just this block header: aborting would throw away every remaining
+        // block and the whole ENTITIES section, as r2000 (which falls
+        // through here) does not.
         if (IS_FROM_TU (dat))
           {
             char *s = bit_convert_TU ((BITCODE_TU)_hdr->name);
-            LOG_ERROR ("BLOCK_HEADER %s first_owned_entity missing", s);
+            LOG_WARN ("BLOCK_HEADER %s first_owned_entity missing, skipped", s);
             free (s);
           }
         else
-          LOG_ERROR ("BLOCK_HEADER %s first_owned_entity missing", _hdr->name);
-        return DWG_ERR_INVALIDDWG;
+          LOG_WARN ("BLOCK_HEADER %s first_owned_entity missing, skipped",
+                    _hdr->name);
+        return 0;
       }
     }
   // Skip all *Model_Space and *Paper_Space entities, esp. new ones: UNDERLAY,


### PR DESCRIPTION
### Symptom

`dwg2dxf` of an r2004 DWG containing one broken/empty BLOCK_HEADER produces a DXF with **zero entities, exit status 0** — silent total data loss. The same drawing as r2000 converts fine.

A reproducible source of such a header: convert any DXF to r2004 with `dxf2dwg` (the import leaves an orphaned duplicate `*Model_Space` BLOCK_HEADER behind, because the reuse check at `case 5:` only merges when the handle happens to match the pre-created object[0]) and feed the result back to `dwg2dxf`.

### Root cause

`dxf_block_write` treats one header without `first_owned_block` as fatal for r2004+:

```c
SINCE (R_2004a)
  {
    LOG_ERROR ("BLOCK_HEADER %s first_owned_entity missing", _hdr->name);
    return DWG_ERR_INVALIDDWG;   // aborts every remaining block + ENTITIES
  }
```

while the r2000 code path falls through and survives — the writer's own version-dependent contradiction.

### Fix

Skip just the broken header (warn), in `out_dxf.c` and `out_dxfb.c`. One damaged table entry must not throw away the model space — same rationale as #1359.

Found by a round-trip fuzzer; `make check` and a 1657-file real-DWG corpus show no regression.
