### PR TITLE
in_dxf: a SPLINE with only fit points is scenario 2, not an empty scenario 1

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -7976,7 +7976,14 @@ add_SPLINE (Dwg_Entity_SPLINE *restrict o, Bit_Chain *restrict dat,
           return 0;
         }
       j = 0;
-      // o->scenario = 2;
+      if (!o->num_ctrl_pts && !o->num_knots)
+        {
+          // Only fit points (e.g. ezdxf output): this can only be stored
+          // as a scenario-2 (bezier) spline. Scenario 1 would encode zero
+          // knots and zero control points: an empty spline, silently lost.
+          o->scenario = 2;
+          LOG_TRACE ("=> SPLINE.scenario = 2 [BL 0] (fit points only)\n");
+        }
       o->flag |= 1024;
       LOG_TRACE ("SPLINE.num_fit_pts = %d [BS 74]\n", o->num_fit_pts);
       return 1; // found


### PR DESCRIPTION
### Symptom

A SPLINE defined by fit points only — what `ezdxf.add_spline()` writes: `70=0, 71=3, 72=0, 73=0, 74=n` plus `11`-groups — **vanishes** through `dxf2dwg`: the DWG carries a scenario-1 spline with zero knots and zero control points, and readers drop it. Exit status 0.

### Root cause

`in_dxf` decides the scenario solely from flag bit 32, which is LibreDWG's own internal marker (standard DXF group 70 has no fit-vs-control bit: 1 closed, 2 periodic, 4 rational, 8 planar, 16 linear). And the correct assignment has been sitting at the 74 handler, **commented out**:

```c
j = 0;
// o->scenario = 2;
o->flag |= 1024;
```

### Fix

Re-enable it, guarded on `!num_ctrl_pts && !num_knots` so AutoCAD-style splines that carry knots+control points *and* fit points keep scenario 1 with their full data. A fit-only spline can only be stored as scenario 2 — with scenario 1 there is nothing to encode.

Found by a round-trip fuzzer (≈600 of 2000 generated drawings lost their spline); `make check` and a 1657-file real-DWG corpus show no regression.
