### PR TITLE
in_dxf: convert r2007+ UTF-8 strings to the pre-r2007 target codepage (mojibake)

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -908,6 +908,42 @@ dxf_read_pair (Bit_Chain *dat)
               pair->value.s.ptr = strdup ("*Paper_Space");
             }
         }
+      if (dat->from_version >= R_2007 && dat->version < R_2007
+          && pair->code != 0 && pair->value.s.ptr && *pair->value.s.ptr)
+        {
+          // An r2007+ DXF is UTF-8-encoded, but the pre-r2007 target stores
+          // codepage strings, and dynapi_set_helper copies them through
+          // unconverted: every non-ASCII char arrives double-encoded in the
+          // DWG. Convert here, so the value carries the same encoding as if
+          // read from a pre-r2007 DXF.
+          size_t len = strlen (pair->value.s.ptr);
+          size_t size = (len * 4) + 8;
+          char *dest = (char *)malloc (size);
+          char *tgt = dest ? bit_utf8_to_TV (dest,
+                                             (unsigned char *)pair->value.s.ptr,
+                                             size, len, 0, dat->codepage)
+                           : NULL;
+          while (dest && !tgt)
+            {
+              char *tmp;
+              size *= 2;
+              if (size >= 1 << 20)
+                break;
+              tmp = (char *)realloc (dest, size);
+              if (!tmp)
+                break;
+              dest = tmp;
+              tgt = bit_utf8_to_TV (dest, (unsigned char *)pair->value.s.ptr,
+                                    size, len, 0, dat->codepage);
+            }
+          if (tgt)
+            {
+              free (pair->value.s.ptr);
+              pair->value.s.ptr = tgt;
+            }
+          else
+            free (dest);
+        }
       break;
     case DWG_VT_BOOL:
       pair->value.i = dxf_read_rc (dat);


### PR DESCRIPTION
### Symptom

`dxf2dwg --as r2000` of any r2007+ DXF (AC1021…AC1032 — UTF-8-encoded by spec) double-encodes every non-ASCII string: `CAÑERÍA Ø150` becomes `CAÃ‘ERÃ\x8dA Ã˜150` in the DWG — layer names, TEXT, MTEXT, ATTRIB values, linetype descriptions alike. Sources up to r2004 are unaffected (their bytes are already in the codepage).

### Root cause

The pair reader hands UTF-8 bytes through, trusting the setter:

```c
// dynapi_set_helper converts from utf-8 to unicode, not here.
```

but `dynapi_set_helper` only honors `is_utf8` for **TU targets** (≥ r2007). Its pre-r2007 "ascii" branch is a plain memcpy, so the UTF-8 bytes land raw in the codepage TV field, and every later reader re-decodes them as cp125x.

### Fix

Convert at `dxf_read_pair`, only for the broken combination (source ≥ r2007, target < r2007), with `bit_utf8_to_TV` and the header codepage — unrepresentable chars degrade to `\U+XXXX` as AutoCAD does. Converting at the reader means the value carries the same encoding as one read from a pre-r2007 DXF, so every downstream consumer (generic dynapi fields, the 15 `dwg_add_u8_input` call sites, EED) behaves identically to the already-working pre-r2007 path.

Related to the encoding work in 7dbfc0e9 (`dwg_add_u8_input`), which covers the add-API but not the DXF importer's generic field path.

Found by a round-trip fuzzer; `make check` and a 1657-file real-DWG corpus show no regression.
