### PR TITLE
bits: keep the palette index when downconverting a CMC whose rgb round-trips

### DIFF
--- a/src/bits.c
+++ b/src/bits.c
@@ -4066,6 +4066,14 @@ bit_downconvert_CMC (Bit_Chain *dat, Dwg_Color *restrict color)
           break;   // ByBlock
         case 0xc2: // Entity
         case 0xc3: // TrueColor
+          // Keep an existing palette index whose rgb round-trips: several
+          // palette entries share one rgb (e.g. 1 and 10, 5 and 170), and
+          // dwg_find_color_index returns the first match, silently
+          // recoloring the entity.
+          if (color->index > 0 && color->index < 256
+              && dwg_rgb_palette_index (color->index)
+                     == (color->rgb & 0x00FFFFFF))
+            break;
           color->index = dwg_find_color_index (color->rgb);
           if (color->index == 256)
             color->index = color->rgb & 0xff;


### PR DESCRIPTION
### Symptom

Writing r2000 from an r2004+ source **silently recolors entities**: ACI 170 (a blue) becomes ACI 5, ACI 10 (a red) becomes ACI 1. Colors with a unique palette rgb survive, which makes the corruption look random.

### Root cause

`bit_downconvert_CMC` rederives the index from the rgb even when a valid palette index is already present:

```c
case 0xc3: // TrueColor
  color->index = dwg_find_color_index (color->rgb);
```

Several ACI entries share one rgb — 1 and 10 are both `FF0000`, 5 and 170 both `0000FF`, the greys repeat too — and `dwg_find_color_index` returns the **first** match.

### Fix

Keep the existing index when its own palette rgb equals the color's rgb (i.e. the pair is consistent); only fall back to the reverse lookup when there is no usable index. 

Found by a round-trip fuzzer (~200 of 2000 generated drawings changed some entity's color); `make check` and a 1657-file real-DWG corpus show no regression.
