### PR TITLE
in_dxf: group 420 lost its method and rgb-present flag — true color dropped in r2004+

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -13064,6 +13064,18 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
                         {
                           color.rgb = pair->value.l;
                           color.method = pair->value.l >> 0x18;
+                          if (!color.method)
+                            {
+                              // a plain 420 RGB has an empty top byte; 0 is
+                              // an invalid CMC method the encoder discards,
+                              // losing the true color. It is method 0xc3.
+                              color.method = 0xc3;
+                              color.rgb |= 0xc3000000;
+                            }
+                          // the r2004+ entity color encoding writes the rgb
+                          // only when the 0x80 rgb-present flag is set, as
+                          // the 440 handler below already does for alpha
+                          color.flag |= 0x80;
                           if (pair->value.l == 257)
                             {
                               color.method = 0xc8;


### PR DESCRIPTION
### Symptom

Every true color (DXF group 420) is **dropped** when `dxf2dwg` writes r2004+: the entity comes back with no rgb at all.

### Root cause — two halves, both in the common-entity 420 handler

1. `color.method = pair->value.l >> 0x18` — the top byte of a plain RGB is 0, an invalid CMC method that the encoder later discards. The sibling `dxf_read_CMC` sets `0xc3` correctly.
2. The r2004+ entity color encoding (`common_entity_data.spec`) writes the rgb only under the `0x80` rgb-present flag:

```c
else if (flags & 0x80) // and not a reference
  FIELD_BLx (color.rgb, 420);
```

and nothing set that flag — while the 440 handler directly below it does set its `0x20` alpha flag. 

### Fix

Set method `0xc3` when the top byte is empty, and set `flag |= 0x80`, mirroring what the 440/alpha handler already does.

Found by a round-trip fuzzer (~320 of 2000 generated drawings, every r2004-target drawing with a true color); `make check` and a 1657-file real-DWG corpus show no regression.
