### PR TITLE
r13/r14: the entity linetype never survived a DXF import (four defects)

### DIFF
--- a/src/common_entity_data.spec
+++ b/src/common_entity_data.spec
@@ -374,10 +374,17 @@
 
   VERSIONS (R_13b1, R_14) //ODA bug
     {
+#ifdef IS_ENCODER
+      // must be derived BEFORE the bit is written; the old fixup in
+      // common_entity_handle_data.spec ran after emission, so every
+      // ByLayer entity went out with isbylayerlt 0 and readers expected
+      // an explicit ltype handle that is not there
+      FIELD_VALUE (isbylayerlt) = FIELD_VALUE (ltype_flags) == 0 ? 1 : 0;
+#endif
       FIELD_B (isbylayerlt, 0);
 #ifdef IS_DECODER
-      if (FIELD_VALUE (isbylayerlt))
-        FIELD_VALUE (ltype_flags) = FIELD_VALUE (isbylayerlt) ? 0 : 3;
+      // the ": 3" arm was dead code under "if (isbylayerlt)"
+      FIELD_VALUE (ltype_flags) = FIELD_VALUE (isbylayerlt) ? 0 : 3;
 #endif
     }
   SINCE (R_2004a) //ODA bug

--- a/src/common_entity_handle_data.spec
+++ b/src/common_entity_handle_data.spec
@@ -64,10 +64,6 @@
   VERSIONS (R_13b1, R_14)
     {
       FIELD_HANDLE (layer, 5, 8);
-#ifdef IS_ENCODER
-      if (dat->from_version == R_2000)
-        FIELD_VALUE (isbylayerlt) = FIELD_VALUE (ltype_flags) < 3 ? 1 : 0;
-#endif
 #ifdef IS_DXF
       PRE (R_2000) {
         switch (FIELD_VALUE (ltype_flags)) {
@@ -85,8 +81,30 @@
         }
       }
 #endif
+#ifdef IS_ENCODER
+      // r13/r14 has no ByBlock/Continuous ltype flags: those entities
+      // reference the LTYPE record by handle. Sources that used the
+      // r2000+ flags carry no handle, so materialize it here.
+      if (!FIELD_VALUE (isbylayerlt)
+          && (!FIELD_VALUE (ltype) || !FIELD_VALUE (ltype)->absolute_ref)
+          && FIELD_VALUE (ltype_flags) >= 1 && FIELD_VALUE (ltype_flags) <= 2)
+        {
+          BITCODE_H _lth = dwg_find_tablehandle (
+              obj->parent,
+              FIELD_VALUE (ltype_flags) == 1 ? (char *)"BYBLOCK"
+                                             : (char *)"CONTINUOUS",
+              "LTYPE");
+          if (_lth && _lth->absolute_ref)
+            FIELD_VALUE (ltype) = dwg_add_handleref (obj->parent, 5,
+                                                     _lth->absolute_ref, NULL);
+        }
+#endif
       if (!FIELD_VALUE (isbylayerlt))
         FIELD_HANDLE (ltype, 5, 6);
+#ifdef IS_DXF
+      // group 48 exists since R13; it was only emitted under R_2000b below
+      FIELD_BD1 (ltype_scale, 48);
+#endif
     }
 
   VERSIONS (R_13b1, R_2000)


### PR DESCRIPTION
### Symptom

Round-trip fuzzing `dxf2dwg --as r14` (ezdxf → DWG → `dwg2dxf` → compare) showed **every entity losing its linetype state**: ByLayer entities came back with an empty group `6`, `CONTINUOUS` became ByLayer, and every custom `ltype_scale` (group 48) vanished. Of 200 drawings only 4 survived; with this patch all 200 do.

### Four defects, one story

1. **`isbylayerlt` is written before it is computed.** The encoder fixup deriving it from `ltype_flags` lives in `common_entity_handle_data.spec` — which runs *after* `common_entity_data.spec` already emitted the bit — and was additionally gated on `from_version == R_2000` exactly. Every ByLayer entity went out with `isbylayerlt 0`, so readers went looking for an explicit ltype handle that is not there.
2. **A dead ternary in the decoder:**
   ```c
   if (FIELD_VALUE (isbylayerlt))
     FIELD_VALUE (ltype_flags) = FIELD_VALUE (isbylayerlt) ? 0 : 3;
   ```
   the `: 3` arm can never execute under that `if`.
3. **ByBlock/Continuous have no handle to write.** r13/r14 knows only bylayer-or-handle — no r2000 flags 1/2 — so those entities must reference the `BYBLOCK`/`CONTINUOUS` LTYPE records by handle. Sources using the flags carry no handle; materialize it via `dwg_find_tablehandle`.
4. **Group 48 was gated on `R_2000b`** in the DXF writer, though per-entity `ltype_scale` exists since R13.

### Verification

`make check` green (254 tests); a 1657-file real-DWG corpus shows no change; the r14 fuzz corpus goes from 2 % to 100 % clean on linetype fields.
