### PR TITLE
in_dxf: MTEXT group 50 is valid — do not reject the whole DXF over it

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -13565,6 +13565,20 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
                   LOG_TRACE ("%s.%s = %f (from DEG %f°) [%s %d]\n", name,
                              "dim_rotation", ang, pair->value.d, "BD", 50);
                 }
+              else if (obj->fixedtype == DWG_TYPE_MTEXT
+                       && pair->code == 50)
+                {
+                  // valid alternative to the group 11 direction vector:
+                  // rotation in degrees (AutoCAD and ezdxf both write it)
+                  Dwg_Entity_MTEXT *o = obj->tio.entity->tio.MTEXT;
+                  BITCODE_BD ang = deg2rad (pair->value.d);
+                  o->x_axis_dir.x = cos (ang);
+                  o->x_axis_dir.y = sin (ang);
+                  o->x_axis_dir.z = 0.0;
+                  LOG_TRACE ("MTEXT.x_axis_dir = (%f, %f, 0) (from DEG %f)"
+                             " [3BD 11 from 50]\n",
+                             o->x_axis_dir.x, o->x_axis_dir.y, pair->value.d);
+                }
               // accept wrong colors
               else if (is_dxf_class_importable (obj->name)
                        && (pair->code < 60 || pair->code > 68))


### PR DESCRIPTION
### Symptom

`dxf2dwg` rejects **the whole DXF** as soon as it contains one rendered dimension:

```
ERROR: Invalid DXF code 50 for MTEXT
ERROR: Failed to decode DXF file
```

Group 50 on MTEXT is the rotation angle — a documented alternative to the group 11 direction vector. AutoCAD writes it, and ezdxf's dimension renderer emits it for every measurement text (`add_linear_dim(...).render()`), so any ezdxf drawing with a dimension currently imports as *nothing*, exit status ≠ 0.

### Fix

Handle MTEXT 50 next to the existing DIMENSION 50/52 special cases, converting degrees to `x_axis_dir`. (The unknown-code-is-fatal fallthrough for importable classes is a separate discussion — this PR just teaches the importer the valid group.)

### Reproducer

```python
import ezdxf
d = ezdxf.new("R2000")
dim = d.modelspace().add_linear_dim(base=(5, 10), p1=(0, 0), p2=(10, 0))
dim.render()
d.saveas("dim.dxf")   # dxf2dwg -y dim.dxf → READ ERROR 0x800
```

`make check` green; 1657-file real-DWG corpus unchanged.
