### PR TITLE
dwg_version_as: accept "r12", which every tool's usage lists as valid

### DIFF
--- a/programs/dwg2dxf.c
+++ b/programs/dwg2dxf.c
@@ -200,7 +200,7 @@ main (int argc, char *argv[])
           dwg_version = dwg_version_as (optarg);
           if (dwg_version == R_INVALID)
             {
-              fprintf (stderr, "Invalid version '%s'\n", argv[1]);
+              fprintf (stderr, "Invalid version '%s'\n", optarg);
               return usage ();
             }
           version = optarg;

--- a/programs/dwgrewrite.c
+++ b/programs/dwgrewrite.c
@@ -232,7 +232,7 @@ main (int argc, char *argv[])
           dwg_version = dwg_version_as (optarg);
           if (dwg_version == R_INVALID)
             {
-              fprintf (stderr, "Invalid version '%s'\n", argv[1]);
+              fprintf (stderr, "Invalid version '%s'\n", optarg);
               return usage ();
             }
           version = optarg;

--- a/programs/dwgwrite.c
+++ b/programs/dwgwrite.c
@@ -265,7 +265,7 @@ main (int argc, char *argv[])
           dwg_version = dwg_version_as (optarg);
           if (dwg_version == R_INVALID)
             {
-              fprintf (stderr, "Invalid version '%s'\n", argv[1]);
+              fprintf (stderr, "Invalid version '%s'\n", optarg);
               return usage ();
             }
           version = optarg;

--- a/programs/dxf2dwg.c
+++ b/programs/dxf2dwg.c
@@ -256,7 +256,7 @@ main (int argc, char *argv[])
           dwg_version = dwg_version_as (optarg);
           if (dwg_version == R_INVALID)
             {
-              fprintf (stderr, "Invalid version '%s'\n", argv[1]);
+              fprintf (stderr, "Invalid version '%s'\n", optarg);
               return usage ();
             }
           version = optarg;

--- a/programs/dxfwrite.c
+++ b/programs/dxfwrite.c
@@ -216,7 +216,7 @@ main (int argc, char *argv[])
           dwg_version = dwg_version_as (optarg);
           if (dwg_version == R_INVALID)
             {
-              fprintf (stderr, "Invalid version '%s'\n", argv[1]);
+              fprintf (stderr, "Invalid version '%s'\n", optarg);
               return usage ();
             }
           version = optarg;

--- a/src/common.c
+++ b/src/common.c
@@ -252,6 +252,11 @@ dwg_version_codes (const Dwg_Version_Type version)
 EXPORT Dwg_Version_Type
 dwg_version_as (const char *version)
 {
+  // "r12" is the common name of the AC1009 format (R_12 == R_11 in the
+  // enum); the tools' usage lists it as valid, but the table (indexed by
+  // enum, so it cannot carry an alias row) only has "r11".
+  if (strEQ (version, "r12"))
+    return R_11;
   for (int i = R_AFTER - 1; i > 0; i--)
     {
       if (strEQ (dwg_versions[i].type, version))


### PR DESCRIPTION
### Symptom

```
$ dxf2dwg -y --as r12 -o out.dwg in.dxf
Invalid version '-y'
```

Two bugs in one line of output:

1. `dxf2dwg --help` advertises **"Valid versions: r12, r14, r2000 (default), r2004"**, but `dwg_version_as` only knows the table string `"r11"` for the AC1009 format — `--as r12` has never been accepted. The table is indexed by the version enum and `R_12 == R_11`, so it cannot carry an alias row; special-case the alias in `dwg_version_as` instead.
2. The error message prints `argv[1]` instead of `optarg`, blaming whatever the first flag was. Fixed in the five tools that share the pattern (dxf2dwg, dwg2dxf, dwgrewrite, dxfwrite, dwgwrite).

With this, `--as r12` reaches the encoder (whose pre-R13 placeholder patching is fixed separately in #PR_B4).
