### PR TITLE
dwg_next_handle: scan all objects for the max, as the comment promises

### DIFF
--- a/src/dwg.c
+++ b/src/dwg.c
@@ -3450,15 +3450,15 @@ dwg_next_handle (const Dwg_Data *dwg)
 {
   long j;
   BITCODE_RLL seed = 0;
-  // check the objects for the highest handle
-  for (j = dwg->num_objects; !seed && j > 0; j--)
+  // check the objects for the highest handle. All of them: during a DXF
+  // import the objects are not in handle order (pre-created table objects
+  // carry high handles before the file's own low handles arrive), and
+  // taking the last nonzero handle hands out handles already in use.
+  for (j = 0; j < (long)dwg->num_objects; j++)
     {
-      Dwg_Object *o = j > 0 ? &dwg->object[j - 1] : NULL;
-      if (o && o->handle.value)
-        {
-          seed = o->handle.value;
-          break;
-        }
+      Dwg_Object *o = &dwg->object[j];
+      if (o->handle.value > seed)
+        seed = o->handle.value;
     }
   // compare against relative handles (deleted and purged?)
   LOG_INSANE ("compute HANDSEED " FORMAT_HV, seed);


### PR DESCRIPTION
### Symptom

Importing an R12 DXF (its own handles present, `$HANDLING` 1):

```
ERROR: Duplicate handle 1F for object 43 already points to object 0
ERROR: Duplicate handle B for object 52 already points to object 29
```

and the emitted DWG's object map points two objects at one handle, so readers resolve the wrong objects.

### Root cause

`dwg_next_handle`'s comment says *"check the objects for the highest handle"* — but the loop takes the handle of the **last** object with a nonzero handle and stops:

```c
for (j = dwg->num_objects; !seed && j > 0; j--)
  { ... seed = o->handle.value; break; }
```

That is only the maximum when objects are appended in increasing handle order. During a DXF import they are not: pre-created table objects carry high handles (0x1F, ...) before the file's own low handles arrive, so fresh objects get handles already in use.

### Fix

Scan all objects for the true maximum, matching the comment and the refs pass below it (which already scans everything).

`make check` green; 1657-file real-DWG corpus unchanged.
