### PR TITLE
encode: a pre-R13 source must still write handle streams for R13+ targets

### DIFF
--- a/src/enc_macros.h
+++ b/src/enc_macros.h
@@ -671,7 +671,8 @@
                  dxf);                                                        \
       LOG_POS                                                                 \
     }                                                                         \
-    IF_ENCODE_SINCE_R13                                                       \
+    SINCE (R_13b1) /* the target, matching the PRE above; a pre-R13 source   \
+                      encoded to R13+ must still write its handle stream */   \
     {                                                                         \
       RESET_VER                                                               \
       if (!hdlptr)                                                            \
@@ -728,7 +729,7 @@
   }
 
 #define FIELD_HANDLE_N(nam, vcount, handle_code, dxf)                         \
-  IF_ENCODE_SINCE_R13                                                         \
+  SINCE (R_13b1) /* the target; see VALUE_HANDLE */                           \
   {                                                                           \
     RESET_VER                                                                 \
     if (!_obj->nam)                                                           \


### PR DESCRIPTION
### Symptom

Encoding an R12 DXF to r2000: **not a single handle is written** — no owners, no block chains, no control entries — and since the objects' declared sizes no longer match their content, reading the result drowns in

```
ERROR: bit_read_RC buffer overflow at 9.0 >= 9
```

(225 errors for a one-LINE drawing; the model space header comes back nameless and empty.)

### Root cause

`VALUE_HANDLE` and `FIELD_HANDLE_N` choose between their two branches with **two different variables**:

```c
PRE (R_13b1)          { /* r11 index style — keyed on the TARGET */ }
IF_ENCODE_SINCE_R13   { /* real handle    — keyed on the SOURCE */ }
```

A pre-R13 *source* encoded to an R13+ *target* satisfies neither branch. Key the second branch on the target (`SINCE (R_13b1)`), complementing the `PRE` above it. Sources that carry no ref for a field still write a NULL handle, preserving stream alignment.

For pre-R13→pre-R13 and r13+→anything nothing changes.

`make check` green; 1657-file real-DWG corpus unchanged; the one-LINE R12→r2000 file drops from 225 read errors to a loadable drawing.
