### PR TITLE
in_dxf: R12 layout blocks are named $MODEL_SPACE, not *Model_Space

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -890,6 +890,24 @@ dxf_read_pair (Bit_Chain *dat)
       LOG_TRACE ("  dxf (%d, \"%s\")\n", (int)pair->code, pair->value.s.ptr);
       // dynapi_set_helper converts from utf-8 to unicode, not here.
       // we need to know the type of the target field, if TV or T
+      if (dat->from_version <= R_12 && pair->code == 2 && pair->value.s.ptr
+          && pair->value.s.ptr[0] == '$')
+        {
+          // AutoCAD R12 DXFs name the layout blocks $MODEL_SPACE and
+          // $PAPER_SPACE; every matcher downstream knows only the r13+
+          // spellings, so such drawings imported with an unfiled model
+          // space and every entity unreachable.
+          if (!strcasecmp (pair->value.s.ptr + 1, "MODEL_SPACE"))
+            {
+              free (pair->value.s.ptr);
+              pair->value.s.ptr = strdup ("*Model_Space");
+            }
+          else if (!strcasecmp (pair->value.s.ptr + 1, "PAPER_SPACE"))
+            {
+              free (pair->value.s.ptr);
+              pair->value.s.ptr = strdup ("*Paper_Space");
+            }
+        }
       break;
     case DWG_VT_BOOL:
       pair->value.i = dxf_read_rc (dat);


### PR DESCRIPTION
### Symptom

Converting any R12 DXF that defines its layout blocks — AutoCAD's own writing convention — loses **every entity of the drawing**: `BLOCK_CONTROL.model_space` stays unset, the model space block header is treated as a user block, and the entities belong to nothing.

### Root cause

R12 DXFs name the layout blocks **`$MODEL_SPACE` / `$PAPER_SPACE`** (ezdxf writes `$Model_Space`). Every matcher in the importer knows only the r13+ spellings `*Model_Space` / `*MODEL_SPACE`.

### Fix

Normalize the `$` spellings to the canonical r13+ names at the pair reader (group 2, pre-R13 sources only), so every downstream matcher — the find-or-create by name, the entmode classifier, the BLOCK_CONTROL model_space hookup — sees one spelling. Case-insensitive, covering AutoCAD's upper-case and ezdxf's mixed-case forms.

`make check` green; 1657-file real-DWG corpus unchanged.
