### PR TITLE
in_dxf: MINSERT column/row count default to 1 when the group is omitted

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -13803,6 +13803,22 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
           LOG_TRACE ("MTEXT.linespace_factor = 1.0 (default) [BD 44]\n");
         }
     }
+  else if (obj->fixedtype == DWG_TYPE_MINSERT)
+    {
+      // the 70/71 groups are omitted when the count is 1; without this a
+      // single-column MINSERT came back as num_cols 0
+      Dwg_Entity_MINSERT *o = obj->tio.entity->tio.MINSERT;
+      if (!o->num_cols)
+        {
+          o->num_cols = 1;
+          LOG_TRACE ("MINSERT.num_cols = 1 (default) [BS 70]\n");
+        }
+      if (!o->num_rows)
+        {
+          o->num_rows = 1;
+          LOG_TRACE ("MINSERT.num_rows = 1 (default) [BS 71]\n");
+        }
+    }
   else if (is_textlike (obj))
     postprocess_TEXTlike (obj);
 


### PR DESCRIPTION
### Symptom

A single-column MINSERT (`71=2`, no `70` group) round-trips as `70=0`: DXF omits INSERT groups 70/71 when the count is 1 — ezdxf and AutoCAD both do — but the importer materialized the missing group as 0, and `dwg2dxf` then writes the explicit 0 back out.

### Fix

Apply the documented defaults when the MINSERT completes, next to the existing 3DFACE default in the same chain. (Setting them earlier, at the `AcDbMInsertBlock` upgrade, does not work: the generic field matcher refuses to overwrite an already-set field when the real 70/71 group arrives.)

```python
import ezdxf
d = ezdxf.new("R2000")
blk = d.blocks.new("B1"); blk.add_circle((0, 0), 1)
ref = d.modelspace().add_blockref("B1", (0, 0))
ref.grid(size=(2, 1), spacing=(10, 10))   # 2 rows, 1 column
d.saveas("minsert.dxf")
```

`make check` green; 1657-file real-DWG corpus unchanged.
