### PR TITLE
cap sscanf field width in dwg_add_PDFUNDERLAY

### DIFF
--- a/src/dwg_api.c
+++ b/src/dwg_api.c
@@ -30805,7 +30805,7 @@ dwg_add_PDFUNDERLAY (Dwg_Object_BLOCK_HEADER *restrict blkhdr,
                     break;
                   }
                 // same base: i++ and inc name
-                sscanf (text, "%s - %d", text1, &i1);
+                sscanf (text, "%79s - %d", text1, &i1);
                 if (strEQ (text1, base))
                   {
                     i++;


### PR DESCRIPTION
AddressSanitizer, stack-buffer-overflow:

    WRITE of size 201 at 0x16f264ea0 thread T0
        #0 scanf_common
        #1 sscanf
        #2 dwg_add_PDFUNDERLAY dwg_api.c:30908
    SUMMARY: AddressSanitizer: stack-buffer-overflow dwg_api.c:30908 in dwg_add_PDFUNDERLAY

text is the ACAD_PDFDEFINITIONS dict entry name from the loaded dwg, so its length is unbounded; the "%s" copies it into char text1[80]. Cap the field to %79s, matching the width-limited name scans elsewhere in the tree.