### PR TITLE
Fix dwgread output

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -389,6 +389,49 @@ strrplc (const char *s, const char *from, const char *to)
     return NULL;
 }
 
+/* replace [rcount1], [rcount2] and [vcount] with concrete indexes. */
+EXPORT char *
+format_field_name (const char *s, long row_count1, long row_count2,
+                   long value_count)
+{
+  char *dest = (char *)calloc (1, 128);
+  size_t j = 0;
+  bool changed = false;
+
+  if (!dest)
+    return NULL;
+  for (size_t i = 0; s[i] && j < 127;)
+    {
+      if (!strncmp (&s[i], "[rcount1]", 9))
+        {
+          j += (size_t)snprintf (&dest[j], 128 - j, "[%ld]", row_count1);
+          i += 9;
+          changed = true;
+        }
+      else if (!strncmp (&s[i], "[rcount2]", 9))
+        {
+          j += (size_t)snprintf (&dest[j], 128 - j, "[%ld]", row_count2);
+          i += 9;
+          changed = true;
+        }
+      else if (!strncmp (&s[i], "[vcount]", 8))
+        {
+          j += (size_t)snprintf (&dest[j], 128 - j, "[%ld]", value_count);
+          i += 8;
+          changed = true;
+        }
+      else
+        dest[j++] = s[i++];
+    }
+  assert (j < 128);
+  if (!changed)
+    {
+      free (dest);
+      return NULL;
+    }
+  return dest;
+}
+
 // naive from scratch implementation, not from glibc.
 // see also examples/unknown.c:membits
 void *__nonnull ((1, 3))

--- a/src/common.h
+++ b/src/common.h
@@ -595,6 +595,9 @@ const unsigned char *dwg_sentinel (const Dwg_Sentinel sentinel_id);
 // used by unit-tests
 EXPORT char *strrplc (const char *s, const char *from,
                       const char *to) __nonnull_all;
+EXPORT char *format_field_name (const char *s, long row_count1,
+                                long row_count2,
+                                long value_count) __nonnull ((1));
 
 #define strEQ(s1, s2) !strcmp ((s1), (s2))
 #define strNE(s1, s2) (strcmp ((s1), (s2)) != 0)

--- a/src/dec_macros.h
+++ b/src/dec_macros.h
@@ -379,8 +379,11 @@
         {                                                                     \
           if (ref)                                                            \
             {                                                                 \
-              LOG_TRACE (#nam ": " FORMAT_REF " [H %d]", ARGS_REF (ref),      \
-                         dxf);                                                \
+              char *_name = format_field_name (#nam, rcount1, rcount2, 0);    \
+              LOG_TRACE ("%s: " FORMAT_REF " [H %d]",                         \
+                         _name ? _name : #nam, ARGS_REF (ref), dxf);          \
+              if (_name)                                                      \
+                free (_name);                                                 \
               if (dwg_ref_object_silent (dwg, ref)                            \
                   && DWG_LOGLEVEL > DWG_LOGLEVEL_TRACE)                       \
                 {                                                             \
@@ -445,10 +448,10 @@
         {                                                                     \
           if (ref)                                                            \
             {                                                                 \
-              char *_name = strrplc (#nam, "[vcount]", "");                   \
-              LOG_TRACE ("%s[%d]: " FORMAT_REF " [H* %d]",                    \
-                         _name ? _name : #nam, (int)vcount, ARGS_REF (ref),   \
-                         dxf);                                                \
+              char *_name = format_field_name (#nam, rcount1, rcount2,        \
+                                               vcount);                       \
+              LOG_TRACE ("%s: " FORMAT_REF " [H* %d]",                        \
+                         _name ? _name : #nam, ARGS_REF (ref), dxf);          \
               if (_name)                                                      \
                 free (_name);                                                 \
               if (dwg_ref_object_silent (dwg, ref)                            \

--- a/src/dec_macros.h
+++ b/src/dec_macros.h
@@ -137,6 +137,14 @@
       free (_name);                                                           \
   }
 
+#define LOG_TRACE_TV_NAME_I(nam, idx, value, dxfgroup)                        \
+  {                                                                           \
+    char *_name = format_field_name (#nam, rcount1, rcount2, idx);            \
+    LOG_TRACE_TV_N (_name ? _name : #nam, value, dxfgroup);                   \
+    if (_name)                                                                \
+      free (_name);                                                           \
+  }
+
 #define LOG_TRACE_TU_NAME(nam, value, dxfgroup)                               \
   {                                                                           \
     char *_name = format_field_name (#nam, rcount1, rcount2, 0);              \
@@ -1293,8 +1301,8 @@
           PRE (R_2007a)                                                       \
           {                                                                   \
             _obj->name[vcount] = bit_read_TV (dat);                           \
-            LOG_TRACE (#name "[%d]: \"%s\" [TV %d]", (int)vcount,             \
-                       _obj->name[vcount], dxf);                              \
+            LOG_TRACE_TV_NAME_I (name[vcount], vcount, _obj->name[vcount],    \
+                                 dxf);                                        \
             LOG_POS                                                           \
             if (!_obj->name[vcount])                                          \
               return DWG_ERR_VALUEOUTOFBOUNDS;                                \

--- a/src/dec_macros.h
+++ b/src/dec_macros.h
@@ -129,6 +129,16 @@
     FIELD_G_TRACE (o.nam, cast, dxf);                                         \
   }
 
+#define LOG_TRACE_TU_NAME(nam, value, dxfgroup)                               \
+  {                                                                           \
+    char *_name = format_field_name (#nam, rcount1, rcount2, 0);              \
+    GCC46_DIAG_IGNORE (-Wformat-nonliteral)                                   \
+    LOG_TRACE_TU (_name ? _name : #nam, value, dxfgroup);                     \
+    GCC46_DIAG_RESTORE                                                        \
+    if (_name)                                                                \
+      free (_name);                                                           \
+  }
+
 #define FIELD_G_TRACE(nam, type, dxfgroup)                                    \
   if (DWG_LOGLEVEL >= DWG_LOGLEVEL_TRACE)                                     \
     {                                                                         \
@@ -654,7 +664,7 @@
 #define FIELD_TU(nam, dxf)                                                    \
   {                                                                           \
     _obj->nam = (BITCODE_TU)bit_read_TU (str_dat);                            \
-    LOG_TRACE_TU (#nam, (BITCODE_TU)FIELD_VALUE (nam), dxf);                  \
+    LOG_TRACE_TU_NAME (nam, (BITCODE_TU)FIELD_VALUE (nam), dxf);              \
   }
 // clang-format on
 #define FIELD_T(nam, dxf)                                                     \
@@ -669,11 +679,11 @@
         if (!obj || obj->has_strings) /* header_vars */                       \
           {                                                                   \
             _obj->nam = (BITCODE_T)bit_read_TU (str_dat);                     \
-            LOG_TRACE_TU (#nam, (BITCODE_TU)FIELD_VALUE (nam), dxf);          \
+            LOG_TRACE_TU_NAME (nam, (BITCODE_TU)FIELD_VALUE (nam), dxf);      \
           }                                                                   \
         else                                                                  \
           {                                                                   \
-            LOG_TRACE_TU (#nam, L"", dxf);                                    \
+            LOG_TRACE_TU_NAME (nam, L"", dxf);                                \
             LOG_INSANE (" !has_strings\n");                                   \
           }                                                                   \
       }                                                                       \

--- a/src/dec_macros.h
+++ b/src/dec_macros.h
@@ -139,6 +139,16 @@
       free (_name);                                                           \
   }
 
+#define LOG_TRACE_TU_NAME_I(nam, idx, value, type, dxfgroup)                  \
+  {                                                                           \
+    char *_name = format_field_name (#nam, rcount1, rcount2, vcount);         \
+    GCC46_DIAG_IGNORE (-Wformat-nonliteral)                                   \
+    LOG_TRACE_TU_I (_name ? _name : #nam, idx, value, type, dxfgroup);        \
+    GCC46_DIAG_RESTORE                                                        \
+    if (_name)                                                                \
+      free (_name);                                                           \
+  }
+
 #define FIELD_G_TRACE(nam, type, dxfgroup)                                    \
   if (DWG_LOGLEVEL >= DWG_LOGLEVEL_TRACE)                                     \
     {                                                                         \
@@ -1284,7 +1294,7 @@
           LATER_VERSIONS                                                      \
           {                                                                   \
             _obj->name[vcount] = (char *)bit_read_##type (dat);               \
-            LOG_TRACE_TU_I (#name, vcount, _obj->name[vcount], type, dxf);    \
+            LOG_TRACE_TU_NAME_I (name, vcount, _obj->name[vcount], type, dxf);\
             if (!_obj->name[vcount])                                          \
               return DWG_ERR_VALUEOUTOFBOUNDS;                                \
           }                                                                   \

--- a/src/dec_macros.h
+++ b/src/dec_macros.h
@@ -129,6 +129,14 @@
     FIELD_G_TRACE (o.nam, cast, dxf);                                         \
   }
 
+#define LOG_TRACE_TV_NAME(nam, value, dxfgroup)                               \
+  {                                                                           \
+    char *_name = format_field_name (#nam, rcount1, rcount2, 0);              \
+    LOG_TRACE_TV_N (_name ? _name : #nam, value, dxfgroup);                   \
+    if (_name)                                                                \
+      free (_name);                                                           \
+  }
+
 #define LOG_TRACE_TU_NAME(nam, value, dxfgroup)                               \
   {                                                                           \
     char *_name = format_field_name (#nam, rcount1, rcount2, 0);              \
@@ -669,7 +677,7 @@
 #define FIELD_TV(nam, dxf)                                                    \
   {                                                                           \
     _obj->nam = bit_read_TV (dat);                                            \
-    LOG_TRACE_TV (#nam ": \"%s\" [TV %d]", _obj->nam, dxf);                   \
+    LOG_TRACE_TV_NAME (nam, _obj->nam, dxf);                                  \
   }
 #define FIELD_TU(nam, dxf)                                                    \
   {                                                                           \
@@ -682,7 +690,7 @@
     if (dat->from_version < R_2007)                                           \
       {                                                                       \
         _obj->nam = bit_read_TV (dat);                                        \
-        LOG_TRACE_TV (#nam ": \"%s\" [TV %d]", _obj->nam, dxf);               \
+        LOG_TRACE_TV_NAME (nam, _obj->nam, dxf);                              \
       }                                                                       \
     else                                                                      \
       {                                                                       \

--- a/src/logging.h
+++ b/src/logging.h
@@ -106,17 +106,20 @@ EXPORT void log_text32 (const unsigned int minlevel, const BITCODE_TU wstr);
     LOG_INSANE (" @%" PRIuSIZE ".%u", dat->byte, dat->bit);                   \
     LOG_TRACE ("\n")
 #endif
-#define LOG_TRACE_TV(fmt, str, dxf)                                           \
+
+#define LOG_TRACE_TV_DO(str, stmt)                                            \
   if (dwg_codepage_isasian ((Dwg_Codepage)dat->codepage))                     \
     {                                                                         \
       char *nstr = bit_TV_to_utf8 (str, dat->codepage);                       \
-      LOG_TRACE (fmt, nstr, dxf);                                             \
+      const char *_tv_str = nstr;                                             \
+      stmt;                                                                   \
       if (nstr && nstr != str)                                                \
         free (nstr);                                                          \
     }                                                                         \
   else                                                                        \
     {                                                                         \
-      LOG_TRACE (fmt, str, dxf);                                              \
+      const char *_tv_str = str;                                              \
+      stmt;                                                                   \
     }                                                                         \
   LOG_POS;                                                                    \
   if (DWG_LOGLEVEL >= DWG_LOGLEVEL_INSANE && str                              \
@@ -125,6 +128,12 @@ EXPORT void log_text32 (const unsigned int minlevel, const BITCODE_TU wstr);
     {                                                                         \
       LOG_INSANE_TF (str, strlen (str));                                      \
     }
+
+#define LOG_TRACE_TV(fmt, str, dxf)                                           \
+  LOG_TRACE_TV_DO (str, LOG_TRACE (fmt, _tv_str, dxf))
+
+#define LOG_TRACE_TV_N(name, str, dxf)                                        \
+  LOG_TRACE_TV_DO (str, LOG_TRACE ("%s: \"%s\" [TV %d]", name, _tv_str, dxf))
 
 #ifdef HAVE_NATIVE_WCHAR2
 #  define LOG_TRACE_TU(s, wstr, dxf)                                          \


### PR DESCRIPTION
Old version of DIMASSOC:
```
Next object: 55 Handleoff: 0xA [UMC]
==========================================
Object number: 55/37, Size: 89 [MS], Type: 503 [BS]
Warning: Unstable Class object 503 DIMASSOC (0x0) 55/0
Add object DIMASSOC [55] Decode object DIMASSOC
bitsize: 623 [RL] @4.2
 Hdlsize: 0x59,
handle: 0.2.10F [H 5]

num_eed: 0
num_reactors: 1 [BL 0]
ownerhandle: (12.1.18) abs:F7 [H 330]
reactors[0]: (4.2.105) abs:105 [H* 330]
xdicobjhandle: (3.0.0) abs:0 [H 360]
unknown_bits [626 (68,555,0) 79 TF]: 40C0088A0B1A23127B9B730B82837B4B73A2932B300A0281207344D323F62870DB0A5111416344624F736E6170506F696E74526566014050240A689A647EC
50E1B614A608C210082982028FB28FB00

associativity: 0x3 [BLx 90]
trans_space_flag: 0 [B 70]
rotated_type: 0x0 [RC 71]
dimensionobj: (4.0.0) abs:0 [H 330]
ref[rcount1].classname: "AcDbOsnapPointRef" [TV 1]
ref[0].osnap_type: 0x1 [RC 72]
ref[0].num_xrefs: 1 [BL 0]
ref[rcount1].xrefs[vcount]: (5.1.F6) abs:F6 [H 331]
ref[0].main_subent_type: 2 [BL 73]
ref[0].main_gsmarker: 3 [BL 91]
ref[0].num_xrefpaths: 0 [BL 0]
ref[0].osnap_dist: 1 [BD 40]
ref[0].osnap_pt: (0, 0, 2e+50) [3BD 10]
ref[0].has_lastpt_ref: 0 [B 75]
ref[rcount1].classname: "AcDbOsnapPointRef" [TV 1]
ref[1].osnap_type: 0x1 [RC 72]
ref[1].num_xrefs: 1 [BL 0]
ref[rcount1].xrefs[vcount]: (5.1.F6) abs:F6 [H 331]
ref[1].main_subent_type: 2 [BL 73]
ref[1].main_gsmarker: 2 [BL 91]
ref[1].num_xrefpaths: 0 [BL 0]
ref[1].osnap_dist: 1 [BD 40]
ref[1].osnap_pt: (0, 0, 2e+50) [3BD 10]
ref[1].has_lastpt_ref: 0 [B 75]
crc: B7F5 [RSx]
 check_CRC 91: B7F5 == B7F5
```

New version after rewrite:
```
Next object: 55 Handleoff: 0xA [UMC]
==========================================
Warning: Unstable Class object 503 DIMASSOC (0x0) 55/0
Add object DIMASSOC [55] Decode object DIMASSOC
bitsize: 623 [RL] @4.2
 Hdlsize: 0x59,
handle: 0.2.10F [H 5]

num_eed: 0
num_reactors: 1 [BL 0]
ownerhandle: (12.1.18) abs:F7 [H 330]
reactors: (4.2.105) abs:105 [H* 330]
xdicobjhandle: (3.0.0) abs:0 [H 360]
unknown_bits [626 (68,555,0) 79 TF]: 40C0088A0B1A23127B9B730B82837B4B73A2932B300A0281207344D323F62870DB0A5111416344624F736E6170506F696E74526566014050240A689A647EC50E1B614A608C210082982028FB28FB00

associativity: 0x3 [BLx 90]
trans_space_flag: 0 [B 70]
rotated_type: 0x0 [RC 71]
dimensionobj: (4.0.0) abs:0 [H 330]
ref[0].classname: "AcDbOsnapPointRef" [TV 1]
ref[0].osnap_type: 0x1 [RC 72]
ref[0].num_xrefs: 1 [BL 0]
ref[0].xrefs[0]: (5.1.F6) abs:F6 [H 331]
ref[0].main_subent_type: 2 [BL 73]
ref[0].main_gsmarker: 3 [BL 91]
ref[0].num_xrefpaths: 0 [BL 0]
ref[0].osnap_dist: 1 [BD 40]
ref[0].osnap_pt: (0, 0, 2e+50) [3BD 10]
ref[0].has_lastpt_ref: 0 [B 75]
ref[1].classname: "AcDbOsnapPointRef" [TV 1]
ref[1].osnap_type: 0x1 [RC 72]
ref[1].num_xrefs: 1 [BL 0]
ref[1].xrefs[0]: (5.1.F6) abs:F6 [H 331]
ref[1].main_subent_type: 2 [BL 73]
ref[1].main_gsmarker: 2 [BL 91]
ref[1].num_xrefpaths: 0 [BL 0]
ref[1].osnap_dist: 1 [BD 40]
ref[1].osnap_pt: (0, 0, 2e+50) [3BD 10]
ref[1].has_lastpt_ref: 0 [B 75]
crc: B7F5 [RSx]
 check_CRC 91: B7F5 == B7F5
```

used ```dwgread -v3```