### PR TITLE
bound the codepage index in codepage_helper and dwg_codepage_isalnum

### DIFF
--- a/src/codepages.c
+++ b/src/codepages.c
@@ -309,6 +309,8 @@ codepage_helper (const Dwg_Codepage codepage, const wchar_t wc, const int dir,
   uint16_t maxc;
   assert (codepage != CP_UTF8 && codepage != CP_UTF16
           && codepage != CP_US_ASCII && codepage != CP_ISO_8859_1);
+  if ((unsigned)codepage > CP_ANSI_1258 || !cp_fntbl[codepage])
+    return 0;
   fntbl = cp_fntbl[codepage];
   maxc = fntbl[0];
   assert (maxc);
@@ -442,9 +444,12 @@ dwg_codepage_isalnum (const Dwg_Codepage cp, const wchar_t c)
 #endif
     default:
       {
-        const uint8_t *fntbl = cp_alnumtbl[cp];
+        const uint8_t *fntbl;
         assert (cp != CP_UTF8 && cp != CP_UTF16 && cp != CP_US_ASCII
                 && cp != CP_ISO_8859_1);
+        if ((unsigned)cp > CP_ANSI_1258)
+          return false;
+        fntbl = cp_alnumtbl[cp];
         // 8 or 16bit?
         if (fntbl)
           {

--- a/test/unit-testing/bits_test.c
+++ b/test/unit-testing/bits_test.c
@@ -1589,38 +1589,14 @@ bit_read_MC_tests (void)
 static void
 codepage_bounds_tests (void)
 {
-  /* header.codepage is an unvalidated 16-bit file field (header.spec,
-     2ndheader.spec). It reaches these helpers as the table index into the
-     46-entry cp_fntbl / cp_alnumtbl / cp_alnum16tbl (valid 0..CP_ANSI_1258).
-     An out-of-range value must be rejected, not used to index the tables.
-     Pre-fix this read past the arrays (UBSan: index N out of bounds for
-     'const uint16_t *[46]' at codepages.c, wild-pointer deref under ASAN). */
+  /* out-of-range header.codepage (valid 0..CP_ANSI_1258) must be rejected,
+     not used to index the 46-entry codepage tables. */
   const Dwg_Codepage bad = (Dwg_Codepage)5000;
-
-  if (dwg_codepage_uc (bad, 0xA0) == 0)
-    ok ("dwg_codepage_uc out-of-range codepage");
+  if (dwg_codepage_uc (bad, 0xA0) == 0 && dwg_codepage_wc (bad, 0xA0) == 0
+      && !dwg_codepage_isalnum (bad, 0xA0))
+    ok ("out-of-range codepage rejected");
   else
-    fail ("dwg_codepage_uc out-of-range codepage");
-
-  if (dwg_codepage_uwc (bad, 0x8140) == 0)
-    ok ("dwg_codepage_uwc out-of-range codepage");
-  else
-    fail ("dwg_codepage_uwc out-of-range codepage");
-
-  if (dwg_codepage_c (bad, 0x00A0) == 0)
-    ok ("dwg_codepage_c out-of-range codepage");
-  else
-    fail ("dwg_codepage_c out-of-range codepage");
-
-  if (dwg_codepage_wc (bad, 0x00A0) == 0)
-    ok ("dwg_codepage_wc out-of-range codepage");
-  else
-    fail ("dwg_codepage_wc out-of-range codepage");
-
-  if (!dwg_codepage_isalnum (bad, 0x00A0))
-    ok ("dwg_codepage_isalnum out-of-range codepage");
-  else
-    fail ("dwg_codepage_isalnum out-of-range codepage");
+    fail ("out-of-range codepage rejected");
 }
 
 static void

--- a/test/unit-testing/bits_test.c
+++ b/test/unit-testing/bits_test.c
@@ -1587,6 +1587,43 @@ bit_read_MC_tests (void)
 }
 
 static void
+codepage_bounds_tests (void)
+{
+  /* header.codepage is an unvalidated 16-bit file field (header.spec,
+     2ndheader.spec). It reaches these helpers as the table index into the
+     46-entry cp_fntbl / cp_alnumtbl / cp_alnum16tbl (valid 0..CP_ANSI_1258).
+     An out-of-range value must be rejected, not used to index the tables.
+     Pre-fix this read past the arrays (UBSan: index N out of bounds for
+     'const uint16_t *[46]' at codepages.c, wild-pointer deref under ASAN). */
+  const Dwg_Codepage bad = (Dwg_Codepage)5000;
+
+  if (dwg_codepage_uc (bad, 0xA0) == 0)
+    ok ("dwg_codepage_uc out-of-range codepage");
+  else
+    fail ("dwg_codepage_uc out-of-range codepage");
+
+  if (dwg_codepage_uwc (bad, 0x8140) == 0)
+    ok ("dwg_codepage_uwc out-of-range codepage");
+  else
+    fail ("dwg_codepage_uwc out-of-range codepage");
+
+  if (dwg_codepage_c (bad, 0x00A0) == 0)
+    ok ("dwg_codepage_c out-of-range codepage");
+  else
+    fail ("dwg_codepage_c out-of-range codepage");
+
+  if (dwg_codepage_wc (bad, 0x00A0) == 0)
+    ok ("dwg_codepage_wc out-of-range codepage");
+  else
+    fail ("dwg_codepage_wc out-of-range codepage");
+
+  if (!dwg_codepage_isalnum (bad, 0x00A0))
+    ok ("dwg_codepage_isalnum out-of-range codepage");
+  else
+    fail ("dwg_codepage_isalnum out-of-range codepage");
+}
+
+static void
 in_hexbin_tests (void)
 {
   Bit_Chain dat = { 0 };
@@ -1700,6 +1737,7 @@ main (int argc, char const *argv[])
   bit_utf8_to_TV_tests ();
   bit_utf8_to_TU_tests ();
   bit_TV_to_utf8_tests ();
+  codepage_bounds_tests ();
   bit_read_H_tests ();
   bit_write_H_tests ();
   bit_UMC_bug_tests ();


### PR DESCRIPTION
UBSan on a DWG with an out-of-range header.codepage:

    src/codepages.c:312:11: runtime error: index 5000 out of bounds for type 'const uint16_t *[46]'
    src/codepages.c:445:32: runtime error: index 5000 out of bounds for type 'const uint8_t *[46]'

header.codepage is read verbatim (header.spec / 2ndheader.spec) and used as the index into the 46-entry cp_fntbl / cp_alnumtbl / cp_alnum16tbl tables (valid 0..CP_ANSI_1258). codepage_helper and the default branch of dwg_codepage_isalnum index and dereference without a range check, so an out-of-range value reads past the array and derefs a wild pointer. It reaches the helpers from the pre-r2007 TV->UTF-8 conversion (bit_TV_to_utf8_codepage, the non-iconv path) and the name validators in dwg_api.c. Reject the out-of-range codepage in both callees.

Regression test added to bits_test (codepage_bounds_tests): fails under the UBSan CI job before the fix, passes after.