### PR TITLE
Three quadratic costs in large imports and dwg_add sessions (fixes #1395)

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -482,6 +482,24 @@ const unsigned char _dwg_VISUALSTYLE_proptypes[58] = {
   /* [56] */ 3, 3
 };
 
+/* A handle vector has no separately tracked capacity, and some call sites
+   (re)allocate one to its exact size.  So PUSH_HV keeps its realloc on every
+   push, but rounds the requested size up to the next power of two: realloc
+   knows the vector's real old size, so the push stays correct however the
+   vector was last allocated, and the calls between two crossings resolve to
+   the same size and do not copy.  N pushes then copy O(N) handles instead of
+   the O(N^2) an exact num+1 realloc costs (GH #1395).
+   Deliberately not static inline in common.h: on a cold path gcc declines to
+   inline it, and -Werror=inline then fails the build (mips32 CI).  */
+size_t
+hv_alloc_size (const size_t num)
+{
+  size_t cap = 8;
+  while (cap < num)
+    cap <<= 1;
+  return cap * sizeof (BITCODE_H);
+}
+
 // returns the first ref from the handle vector.
 BITCODE_H
 shift_hv (BITCODE_H *hv, BITCODE_BL *num_p)

--- a/src/common.h
+++ b/src/common.h
@@ -630,12 +630,16 @@ void *memmem (const void *h0, size_t k, const void *n0, size_t l)
 #  endif
 #endif
 
+/* The byte size to (re)allocate a handle vector of num entries with.
+   See src/common.c.  */
+size_t hv_alloc_size (size_t num);
+
 // push to handle vector at the end. It really is unshift.
 #define PUSH_HV(_obj, numfield, hvfield, ref)                                 \
   if (_obj->numfield <= 0 || _obj->hvfield[_obj->numfield - 1] != ref)        \
     {                                                                         \
       _obj->hvfield = (BITCODE_H *)realloc (                                  \
-          _obj->hvfield, (_obj->numfield + 1) * sizeof (BITCODE_H));          \
+          _obj->hvfield, hv_alloc_size (_obj->numfield + 1));                 \
       _obj->hvfield[_obj->numfield] = ref;                                    \
       LOG_TRACE ("%s[%d] = " FORMAT_REF " [H]\n", #hvfield, _obj->numfield,   \
                  ARGS_REF (_obj->hvfield[_obj->numfield]));                   \
@@ -649,7 +653,7 @@ void *memmem (const void *h0, size_t k, const void *n0, size_t l)
       || find_hv (_obj->hvfield, _obj->numfield, ref->absolute_ref) < 0)      \
     {                                                                         \
       _obj->hvfield = (BITCODE_H *)realloc (                                  \
-          _obj->hvfield, (_obj->numfield + 1) * sizeof (BITCODE_H));          \
+          _obj->hvfield, hv_alloc_size (_obj->numfield + 1));                 \
       _obj->hvfield[_obj->numfield] = ref;                                    \
       LOG_TRACE ("%s[%d] = " FORMAT_REF " [H]\n", #hvfield, _obj->numfield,   \
                  ARGS_REF (_obj->hvfield[_obj->numfield]));                   \

--- a/src/decode.c
+++ b/src/decode.c
@@ -4633,7 +4633,11 @@ dwg_decode_add_object_ref (Dwg_Data *restrict dwg, Dwg_Object_Ref *ref)
                                * sizeof (Dwg_Object_Ref *));
       memset (&dwg->object_ref[dwg->num_object_refs], 0,
               REFS_PER_REALLOC * sizeof (Dwg_Object_Ref *));
-      dwg->dirty_refs = 1;
+      /* No dirty_refs here: only the array of POINTERS moved.  The refs
+         it points to, and their cached ref->obj, are untouched -- unlike
+         dwg_add_object, which dirties only when dwg->object itself moved.
+         Dirtying per chunk made every 16384th ref trigger a full
+         dwg_resolve_objectrefs_silent sweep: O(N^2) imports (GH #1395). */
       LOG_TRACE ("REALLOC dwg->object_ref vector to %u\n",
                  dwg->num_object_refs + REFS_PER_REALLOC);
     }

--- a/src/dwg.c
+++ b/src/dwg.c
@@ -3986,17 +3986,21 @@ bsearch_ex (const void *pKey, const void *pBase, size_t numBase,
   return NULL;
 }
 
+/* absolute_ref is the primary key on purpose: refs are created in roughly
+   ascending handle order, so with the handle first a new ref lands at the
+   END of the array and ordered_ref_add's memmove copies nothing.  With the
+   code first it lands at the end of its code block, in the MIDDLE, and
+   every insert shifts all higher-code refs: O(N^2) over an import
+   (GH #1395).  The order is private to ordered_ref_add/ordered_ref_find,
+   which both use this comparator.  */
 static int
 Ref_cmp (const void *key, const void *elem)
 {
   const Dwg_Object_Ref *pKey = (const Dwg_Object_Ref *)key;
   const Dwg_Object_Ref *pR = *(const Dwg_Object_Ref **)elem;
-  int retVal = (int)pKey->handleref.code - (int)pR->handleref.code;
-  if (0 != retVal)
-    return retVal;
-  return pKey->absolute_ref > pR->absolute_ref    ? 1
-         : pKey->absolute_ref == pR->absolute_ref ? 0
-                                                  : -1;
+  if (pKey->absolute_ref != pR->absolute_ref)
+    return pKey->absolute_ref > pR->absolute_ref ? 1 : -1;
+  return (int)pKey->handleref.code - (int)pR->handleref.code;
 }
 
 void


### PR DESCRIPTION
Fixes #1395, whose analysis of `PUSH_HV` is confirmed — and profiling the reproducer turned up two more independent quadratic costs on the same path. One commit per root cause, 33 lines total:

1. **`PUSH_HV` / `PUSH_HV_NEW` realloced to exactly num+1 on every push** (the cost #1395 diagnosed). A handle vector has no tracked capacity and some call sites allocate one to its exact size, so the realloc-per-push stays — but the requested size is now rounded up to the next power of two: calls between two crossings resolve to the same usable size and do not copy, and realloc knows the vector's real old size, so the push is correct however the vector was last allocated. N pushes copy O(N) handles instead of O(N²). This dominates on allocators without mremap-style in-place growth (it is why the issue's measurements are much worse than what glibc shows).

2. **`Ref_cmp` compared `handleref.code` first**, so a new ref — whose handle is the highest so far — sorted to the end of its code block, in the *middle* of the ordered index, and every `ordered_ref_add` memmoved all higher-code refs one slot up. With `absolute_ref` as the primary key a new ref lands at the end and the memmove copies nothing. The order is private to `ordered_ref_add`/`ordered_ref_find`, which both use this comparator.

3. **`dwg_decode_add_object_ref` set `dirty_refs = 1` every time the ref pointer array grew by a chunk** (16384 refs). That realloc moves only the array of *pointers*; the refs and their cached `ref->obj` are untouched. Its sibling `dwg_add_object` already demonstrates the correct criterion — dirty only when `dwg->object` itself moved. The spurious flag made the next `dwg_ref_object` run a full `dwg_resolve_objectrefs_silent` sweep, once per 16384 refs: gprof shows 36 full sweeps / 7.6M resolves for 120k adds. This was the dominant cost on glibc.

**Measured** (loop of `dwg_add_LINE` into modelspace, glibc/Linux, -O2):

| N | master | patched |
|---:|---:|---:|
| 40 000 | 0.16 s | 0.07 s |
| 160 000 | 2.09 s | 0.39 s |
| 640 000 | 29.62 s | 1.84 s |

Per-add cost is now flat (µs/add 1.7 → 2.9 over 16× N; master grows 3.9 → 46.3). `dxf2dwg --as r2000` of a 300k-entity DXF: 2.49 s → 1.71 s, output byte-identical.

**Verified**: `make check` all green; a 1657-file real-DWG corpus converts with identical entity counts and content signatures to master (0 regressions); a 400-seed DXF→DWG→DXF round-trip fuzz campaign is result-identical to master, seed by seed; the DWGs written from large DXFs are byte-identical.