### PR TITLE
in_dxf: do not double the ACAD_ prefix in CHECK_DICTIONARY_HDR's fallback (fixes #1390)

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -14919,8 +14919,12 @@ resolve_postponed_object_refs (Dwg_Data *restrict dwg)
         if (vars->DICTIONARY_##name)                                          \
           LOG_TRACE ("HEADER.DICTIONARY_" #name " = " FORMAT_REF "\n",        \
                      ARGS_REF (vars->DICTIONARY_##name));                     \
-        else if ((vars->DICTIONARY_##name                                     \
-                  = dwg_find_dictionary (dwg, "ACAD_" #name)))                \
+        /* the fallback prepends ACAD_; skip it when the name already      \
+           carries the prefix (ACAD_GROUP, ACAD_MLINESTYLE), else we'd     \
+           search for a doubled ACAD_ACAD_ prefix that can never exist */  \
+        else if (!memBEGINc (#name, "ACAD_")                                  \
+                 && (vars->DICTIONARY_##name                                  \
+                     = dwg_find_dictionary (dwg, "ACAD_" #name)))             \
           LOG_TRACE ("HEADER.DICTIONARY_" #name " = " FORMAT_REF "\n",        \
                      ARGS_REF (vars->DICTIONARY_##name));                     \
       } /* set owner to NOD 4.1.C */                                          \


### PR DESCRIPTION
Exactly the defect #1390 diagnosed: `CHECK_DICTIONARY_HDR` uses its single argument both as the header-field suffix and as the dictionary name to look up, and two of its eight call sites pass a name that already begins with `ACAD_`, so their fallback searched for a doubled `ACAD_ACAD_` prefix that can never exist and logged a misleading line. The fallback is now skipped for pre-prefixed names.

Verified with an R2000 DXF that sets `$CMLSTYLE` but carries no `ACAD_MLINESTYLE` / `ACAD_GROUP` dictionary: `dxf2dwg -v4` logs the two `ACAD_ACAD_*` lookups on master and none with the patch, the produced DWG is byte-identical, and `make check` stays green. Cosmetic only — the bogus lookup could never succeed — but it costs real time to whoever is reading a verbose log, which is how #1390 found it.