### PR TITLE
in_dxf: MTEXT spacing fields default when their group is omitted

### DIFF
--- a/src/in_dxf.c
+++ b/src/in_dxf.c
@@ -13778,6 +13778,31 @@ static __nonnull ((1, 2, 3, 4)) Dxf_Pair *new_object (
       o->has_no_flags = 1;
       LOG_TRACE ("_3DFACE.has_no_flags = 1 [B]\n");
     }
+  else if (obj->fixedtype == DWG_TYPE_MTEXT)
+    {
+      // DXF omits the optional groups 72/73/44 when they hold their default
+      // (ezdxf and AutoCAD both do), and importing the missing group as 0
+      // gave such an MTEXT a line spacing factor of 0.0 — every line of the
+      // paragraph draws on top of the first one. 0 is not a valid value for
+      // any of the three (the factor's documented range is 0.25-4.0), so
+      // this can never override a real value.
+      Dwg_Entity_MTEXT *o = obj->tio.entity->tio.MTEXT;
+      if (!o->flow_dir)
+        {
+          o->flow_dir = 1;
+          LOG_TRACE ("MTEXT.flow_dir = 1 (default) [BS 72]\n");
+        }
+      if (!o->linespace_style)
+        {
+          o->linespace_style = 1;
+          LOG_TRACE ("MTEXT.linespace_style = 1 (default) [BS 73]\n");
+        }
+      if (o->linespace_factor == 0.0)
+        {
+          o->linespace_factor = 1.0;
+          LOG_TRACE ("MTEXT.linespace_factor = 1.0 (default) [BD 44]\n");
+        }
+    }
   else if (is_textlike (obj))
     postprocess_TEXTlike (obj);
 


### PR DESCRIPTION
`in_dxf` stores an omitted optional group as 0 instead of its documented default. For MTEXT the visible casualty is the line spacing: DXF omits groups 72 (flow direction), 73 (line spacing style) and 44 (line spacing factor) when they hold their default — ezdxf and AutoCAD both do — so an ordinary multi-line MTEXT imports with `linespace_factor = 0.0`, and **every line of the paragraph draws on top of the first one**. `dwg2dxf` then writes the explicit 0 back out, so the corruption survives round trips.

### Reproducer (one entity)

```sh
python3 -c "import ezdxf; d = ezdxf.new('R2000'); \
  d.modelspace().add_mtext('LINE ONE\\\\PLINE TWO', dxfattribs={'char_height': 1.0}); \
  d.saveas('two-lines.dxf')"
dxf2dwg two-lines.dxf -y -o two-lines.dwg
dwg2dxf two-lines.dwg -y -o back.dxf
grep -A1 ' 44$' back.dxf
```

Before: group 44 comes back `0.0` (72 and 73 come back 0 as well). With this patch: `1.0` / 1 / 1.

### The fix

Set the three defaults when the object completes, next to the existing `_3DFACE` default — the same shape as the MINSERT column/row default of PR #1385. 0 is not a valid value for any of the three fields (the factor's documented range is 0.25–4.0), so the defaults can never override a real value; verified with a non-default MTEXT (factor 0.8, style 2, flow 3), which round-trips unchanged.

Verified on a pristine 0.14.8583 tree with only this patch: the reproducer's fields come back 1/1/1.0, and `make check` passes.

Found dogfooding IngeCAD: a colleague's plan full of two-line labels saved to DWG came back with every label's lines stacked on one another.
