### PR TITLE
out_dxf: number a layout's viewports per block, not per entmode

### DIFF
--- a/include/dwg.h
+++ b/include/dwg.h
@@ -11398,6 +11398,7 @@ typedef struct _dwg_struct
   BITCODE_BL num_object_refs;    /*!< number of object_ref's (resolved handles) */
   BITCODE_BL cur_index;          /*!< how many we have written currently */
   BITCODE_RS last_viewport_id;   /*!< auto-incremented VIEWPORT id for DXF */
+  BITCODE_RLL last_viewport_owner; /*!< block the counter above belongs to */
   Dwg_Object_Ref **object_ref;   /*!< array of most handles */
   struct _inthash *object_map;   /*!< map of all handles */
   int dirty_refs;                /* 1 if we added an object, and invalidated all

--- a/src/dwg.spec
+++ b/src/dwg.spec
@@ -2424,15 +2424,35 @@ DWG_ENTITY (VIEWPORT)
     FIELD_BD (height, 41);
   }
   DXF {
-    // The overall paperspace viewport (entmode 0) has on_off=0, id=0.
-    // Active viewports auto-increment id starting at 1.
-    if (_ent->entmode == 0) {
-      FIELD_VALUE (on_off) = 0;
-      FIELD_VALUE (id) = 0;
-      dwg->last_viewport_id = 0;
-    } else {
-      FIELD_VALUE (on_off) = 1;
+    // Neither field is stored in a DWG, so both are derived. AutoCAD numbers
+    // the viewports of EACH layout 1..N and turns none of them off, so the
+    // counter belongs to the block the viewport lives in.
+    //
+    // It used to restart on entmode 0, taking that for "the overall
+    // paperspace viewport". But entmode 0 only says the entity carries an
+    // explicit owner handle, which is how every layout stores its entities
+    // except the one that was current when the file was saved: every
+    // viewport of every other layout came out off (68 = 0, 69 = 0), and a
+    // consumer that honors the status draws an empty sheet.
+    //
+    // The owning block is derived exactly as the group 330 in
+    // common_entity_handle_data.spec derives it.
+    {
+      Dwg_Object_Ref *_owner_ref
+          = _ent->ownerhandle    ? _ent->ownerhandle
+            : _ent->entmode == 1 ? dwg->header_vars.BLOCK_RECORD_PSPACE
+            : _ent->entmode == 2 ? dwg->header_vars.BLOCK_RECORD_MSPACE
+                                 : NULL;
+      const BITCODE_RLL _owner = _owner_ref ? _owner_ref->absolute_ref : 0;
+      if (_owner != dwg->last_viewport_owner)
+        {
+          dwg->last_viewport_owner = _owner;
+          dwg->last_viewport_id = 0;
+        }
       dwg->last_viewport_id++;
+      // 68 is not a boolean: a positive value is the stacking order, "1 is
+      // the active viewport, 2 is the next, and so forth".
+      FIELD_VALUE (on_off) = dwg->last_viewport_id;
       FIELD_VALUE (id) = dwg->last_viewport_id;
     }
     FIELD_RS (on_off, 68);


### PR DESCRIPTION
DXF groups 68 (viewport status) and 69 (viewport id) are not stored in a DWG — they exist only in the `DXF { }` block of the VIEWPORT spec — so the writer has to derive them, and it derived them from `entmode`:

```c
if (_ent->entmode == 0) {        // "the overall paperspace viewport"
  on_off = 0; id = 0; last_viewport_id = 0;
} else {
  on_off = 1; id = ++last_viewport_id;
}
```

`entmode` 0 does not mean "the overall paperspace viewport". It means the entity carries an explicit owner handle, which is how **every layout stores its entities except the one that was current when the file was saved** (that one gets entmode 1, PSPACE implied). So in a drawing with more than one layout, every viewport of every other layout was written off — `68 = 0, 69 = 0` — and a consumer that honors the status draws an empty sheet.

Found on a real construction drawing with five layouts: 47 viewports with entmode 0, 3 with entmode 1, so four of the five sheets rendered blank while ODAFileConverter, reading the same DWG, numbers the viewports of each layout 1..N and turns none of them off.

### What the patch does

The counter belongs to the block the viewport lives in and restarts when that block changes. The block is derived exactly as the group 330 right above it in `common_entity_handle_data.spec` derives it: the explicit owner handle when there is one, else the {p,m}space block record the entmode implies. 68 gets the same number as 69, because group 68 is not a boolean but the stacking order — *"1 is the active viewport, 2 is the next, and so forth"* — so a constant 1 left the order of a layout's viewports undefined for a reader that sorts by it.

Viewports owned by an ordinary block (AutoCAD's `A$C...` paste blocks carry them, and so do `$AUDIT_BAD_BLOCK_RECORD*` after a repair) keep the 0 they have always been written with: they are not a view of a sheet, and ODA numbers none of them either — it writes `69 = -1` and no 68 there, which an unsigned `BITCODE_RS` cannot hold. An owner that cannot be resolved is still numbered, and so is a `'*'`-named {p,m}space block with no LAYOUT object, which is how R13/R14 files keep their paper space.

### Measured

1657 real DWGs, master vs this patch, same criterion on both sides (13941 viewports in 1170 files):

| | master | patched |
|---|---|---|
| viewports written off | 6825 | 424 (all in ordinary blocks) |
| layout blocks with every viewport off | 1307 | **0** |
| layout blocks turned off (regression) | — | **0** |
| files whose viewport count changed | — | **0** |
| new conversion failures | — | **0** |

Against ODAFileConverter, per layout, on the drawing above: all five layouts now come out `(1,1) (2,2) …` exactly as ODA writes them, where master wrote `(0,0)` for four of the five. The R13/R14 files of the corpus (`example_r13`, `example_r14`) also match ODA exactly now.

`make check`: 254/254.

The `'*'` name test is version-safe (`IS_FROM_TU`, the same first-code-unit comparison `dwg_is_valid_name_u8` makes). Both of its branches were exercised on purpose, with a probe build where that test was the only condition left: the R2018 drawing (UTF-16 names) numbers its five layouts, the R14 file (codepage names) numbers its two.

### Related

#1213 is the neighbouring symptom. I ran its `layout.dwg` through both builds: master already writes `69 = 1` and `69 = 2` for its two viewports, so the ids are right there; what changes is 68, which master wrote as `1, 1` and this patch writes as the stacking order `1, 2`. The reporter reads `id` through the API, where both fields are still 0 — the derivation lives in the `DXF { }` block, so nothing sets them when a DWG is decoded. Deriving both once after decoding, so `dwg_entity_VIEWPORT.id` carries them too, would be the fuller answer; I am happy to do that instead if you prefer it.
