### PR TITLE
Fix 1412 cquote terminate

### DIFF
--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -1478,6 +1478,14 @@ static void
 dxf_write_chunked (Bit_Chain *restrict dat, const char *restrict str,
                    size_t len, const int dxf)
 {
+  // A value that quoted away to nothing still needs its group written.
+  // Emitting no code at all shifts every following tag in the file.
+  if (!len)
+    {
+      GROUP (dxf);
+      fputs ("\r\n", dat->fh);
+      return;
+    }
   while (len > 0)
     {
       size_t chunk = len > 250 ? 250 : len;

--- a/src/out_dxf.c
+++ b/src/out_dxf.c
@@ -1393,6 +1393,12 @@ cquote (char *restrict dest, const size_t len, const char *restrict src)
       else
         *dest++ = c;
     }
+  // Terminate after the LAST BYTE WRITTEN. Callers strlen() this buffer, so
+  // a NUL only at its end makes every byte the quoting did not reach part of
+  // the string -- uninitialized heap, for a buffer sized 2x the input.
+  if (dest >= dend)
+    dest = d + len - 1;
+  *dest = '\0';
   d[len - 1] = '\0'; // add final delim, skipped above
   return d;
 }


### PR DESCRIPTION
Fixes the uninitialized-heap read in #1412. Two commits: the fix, and a related
guard that is hardening rather than a live defect — see the last section, and
drop it if you disagree with it.

`cquote()` NUL-terminates at `d[len - 1]` — the end of the destination *buffer* —
rather than after the last byte it wrote. `dxf_fixup_string()` then `strlen()`s
that buffer, so the gap between the quoted string and the end of the allocation
becomes part of the DXF value. The buffer is `malloc ((2 * emblen) + 1)`, so
every string that grows by less than 2x under quoting has such a gap.

### Reproducer — shipped test data, no `MALLOC_PERTURB_` needed

On master (`0.14.8594`), stock build:

```console
$ programs/dwg2dxf --as r2018 -y -o out.dxf test/test-data/example_2018.dwg
$ grep -a Fgdt out.dxf
{\Fgdt;r}%%v1%%v2%%v%%v%%v^J10v
                              ^ not in the drawing
```

That value quotes to 30 bytes in a 59-byte buffer, and `strlen()` runs past what
was written. Same on `example_2004`, `_2007`, `_2010` and `_2013`. Under
`MALLOC_PERTURB_` the residue is a long run rather than a single byte — which is
how it first surfaced — but master reproduces it plainly.

### Two corrections to the issue text

I said in #1412 that I had not compiled master. I have now, and two claims there
need amending:

- **`dwg_write_dxfb()` is not affected.** `out_dxfb.c` writes values through
  `VALUE_TV` / `VALUE_TU` with a raw `fprintf` and never reaches `cquote`. The
  affected surfaces are `dwg2dxf`, `dwgread -O DXF` and `dwg_write_dxf()`.
- **No allocator fill pattern is needed on master.** The shipped `example_*.dwg`
  reproduce with a plain build.

The hunk itself applies to master unchanged — `64c1e225` rewrote the caller, not
`cquote`.

### Verification

Two `dwg2dxf` binaries built from one tree with identical flags, differing only
in the first commit's hunk. Corpus: all 141 shipped `test/test-data/*.dwg` plus 43 real
AutoCAD-authored R2018 drawings — 184 total, 0 conversion failures on either
binary.

The signature of this bug is that the output depends on what the allocator hands
back, so the primary measurement is per binary: convert every drawing three
times — `MALLOC_PERTURB_` unset, `=42`, `=170` — and check whether the three
agree.

| | stock | patched |
|---|---|---|
| drawings whose output depends on `MALLOC_PERTURB_` | 3 | **0** |
| plain-run output differing between the two binaries | \- | 8 of 184 |

Those 8 are the 5 shipped `example_*.dwg` and the same 3 real drawings that are
allocator-dependent on stock; nothing else moves. On `example_2018` the patched
output is byte-for-byte the expected value above, with and without
`MALLOC_PERTURB_`.

A third binary with both commits applied produces **byte-identical output to the
first commit alone on all 184**, which is what the second commit's status below
predicts.

`make check` with both commits applied: 259 PASS, 0 FAIL, exit 0 — `All 254
tests passed` in `test/unit-testing`, plus `programs` and `examples`.

`clang-format` leaves `src/out_dxf.c` unchanged, with both hunks applied.

Host/target: `x86_64-pc-linux-gnu`, Debian 12, gcc 12.2.0, configured
`--disable-bindings --disable-python --disable-docs --disable-shared
--enable-static`.

### Testcase

I have not added one, and would rather ask than guess where it belongs. The
current suite cannot see this defect — the residue lands inside a DXF value, and
every shipped drawing converts "successfully" with it. The regression test that
would catch it is running an existing DXF conversion with `MALLOC_PERTURB_` set
and diffing against the unperturbed run, which covers the whole class rather
than this one instance. Happy to add that wherever you would like it.

### Copyright

14 added lines across the two commits (6 and 8), which I read as under the
15-line threshold in `CONTRIBUTING` — but close enough to it that I am glad to
file a disclaimer or an assignment if you would rather have one on file.

### The second commit is hardening, not a second bug

`dxf_write_chunked()` is a bare `while (len > 0)`, and `dxf_fixup_string()` emits
the empty-value form only from its outer `else`. A non-empty input whose quoted
form came out empty would therefore emit no group code at all, shifting every
following tag in the file.

I would rather state its status plainly than oversell it: **I could not construct
an input that reaches this on master.** `cquote`'s invalid-MIF path needs
`s + 6 < send` to enter and consumes only 4 bytes, so it always leaves trailing
bytes for the `else` branch to write, and `bit_embed_TU` does not return an empty
string for a non-empty input. Output is unchanged on all 184 drawings above,
exactly as a guard on an unreachable state should be.

What it closes is the same "the length is whatever `strlen` says" assumption as
the first commit. It is a separate commit so you can drop it if you would rather
not carry a guard for a state you cannot reach — the first commit stands alone.
